### PR TITLE
Fix category select dropdown not appearing above modal overlay

### DIFF
--- a/src/components/feed/feed-step.tsx
+++ b/src/components/feed/feed-step.tsx
@@ -292,7 +292,7 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
           <SelectTrigger>
             <SelectValue />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent className="z-[70]">
             <SelectItem value="__none__">{t('category.uncategorized')}</SelectItem>
             {categories.map(cat => (
               <SelectItem key={cat.id} value={String(cat.id)}>{cat.name}</SelectItem>


### PR DESCRIPTION
### Problem

In the Add Feed modal, the category select content was not visible when opened. This was caused by the SelectContent having a lower z-index than the DialogOverlay.

Issue screenshot of demo:

<img width="440" height="412" alt="Add Feed modal" src="https://github.com/user-attachments/assets/69e0078d-7145-415c-9272-357bb848acf5" />

### Solution

Increased the z-index of SelectContent in `FeedStep` to ensure it renders above DialogOverlay.