### PR TITLE
Update task model section to include Claude Code Ready in key checks

### DIFF
--- a/src/pages/settings/sections/task-model-section.tsx
+++ b/src/pages/settings/sections/task-model-section.tsx
@@ -58,7 +58,7 @@ export function TaskModelSection({ settings, t }: { settings: Settings; t: TFunc
     anthropicKey.data?.configured, geminiKey.data?.configured, openaiKey.data?.configured,
     googleTranslateKey.data?.configured, deeplKey.data?.configured, claudeCodeReady,
   ])
-  const hasAnyLlmKey = LLM_API_PROVIDERS.some(p => configuredKeys[p])
+  const hasAnyLlmKey = LLM_API_PROVIDERS.some(p => configuredKeys[p]) || claudeCodeReady
   const hasAnyTranslateKey = TRANSLATE_SERVICE_PROVIDERS.some(p => configuredKeys[p])
   const hasAnyKey = hasAnyLlmKey || hasAnyTranslateKey
   const keysLoading = llmKeyStatuses.some(s => !s.data) || translateKeyStatuses.some(s => !s.data)


### PR DESCRIPTION
  ## Summary

Fix task settings section being disabled when only Claude Code is authenticated and no API keys are configured.

`hasAnyLlmKey` only checked `LLM_API_PROVIDERS` (anthropic, gemini, openai) but did not include Claude Code's authentication status. When Claude Code was the only authenticated provider, `hasAnyKey` evaluated to `false`, causing the entire task settings section to be grayed out with "Cannot change settings because no API keys are configured.

<img width="1050" height="1678" alt="CleanShot 2026-03-18 at 19 20 06" src="https://github.com/user-attachments/assets/579f6810-a8d8-4898-a5f2-3aa9b60fd7ac" />
