### PR TITLE
Add mocks for unused components and hooks in `article-list.test.tsx`

### DIFF
--- a/src/components/article/article-list.test.tsx
+++ b/src/components/article/article-list.test.tsx
@@ -89,6 +89,22 @@ vi.mock('./article-card', () => ({
   ),
 }))
 
+vi.mock('./article-overlay', () => ({
+  ArticleOverlay: () => null,
+}))
+
+vi.mock('../feed/feed-error-banner', () => ({
+  FeedErrorBanner: () => null,
+}))
+
+vi.mock('../ui/skeleton', () => ({
+  Skeleton: ({ className }: { className?: string }) => <div data-testid="skeleton" className={`animate-pulse ${className ?? ''}`} />,
+}))
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }),
+}))
+
 import { ArticleList } from './article-list'
 
 function makeArticle(overrides: Partial<ArticleListItem> = {}): ArticleListItem {


### PR DESCRIPTION
## Summary

Fix OOM crash in `article-list.test.tsx` by adding mocks for heavy unmocked dependencies.

The test was crashing with "JavaScript heap out of memory" on CI (6GB limit) and timing out locally. Four modules were loaded with their full dependency trees without being mocked — in particular, `article-overlay` pulls in `article-detail`, which transitively imports chat, markdown rendering, sanitize, summarize, and translate modules. When these interact with the jsdom test environment,  memory usage grows far beyond what the import sizes alone would suggest.

Added mocks for:
- `article-overlay`
- `sonner`
- `feed-error-banner`
- `ui/skeleton`

With these mocked, the test completes in ~10s instead of OOM.