### PR TITLE
Perf/score recalc daily batch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@
 # LOG_LEVEL=debug               (default: info)
 # TZ=Asia/Tokyo                 (default: UTC)
 # AUTH_DISABLED=1               (development only)
+# SCORE_RECALC_SCHEDULE=0 3 * * *  (default: */5 * * * *; set to daily if event-driven covers all actions)
 #
 # Production (compose.prod.yaml):
 # MEILI_MASTER_KEY=<string>     (required for production Meilisearch)

--- a/docs/spec/91_perf_score_recalculation.md
+++ b/docs/spec/91_perf_score_recalculation.md
@@ -64,51 +64,53 @@ Issues:
 | AI chat tools | Via search results | No — dynamically computed |
 | Smart Floor | Not used | No |
 
-## Approach: Replace 5-Minute Cron Batch with Daily Decay Batch
+## Approach: Decouple Score Recalculation from Feed Fetch
 
-Since event-driven updates already handle engagement changes instantly, the cron batch's role is reduced to daily time-decay refresh only.
+Separate score recalculation into its own cron with a configurable schedule (`SCORE_RECALC_SCHEDULE`). Add Meilisearch sync after each recalculation. The default frequency stays at 5 minutes for safety; deployments confident in event-driven coverage can reduce to daily.
 
 ### Changes
 
 1. `server/index.ts`: Remove the `recalculateScores()` call from the feed-fetch cron (`CRON_SCHEDULE`)
-2. `server/index.ts`: Add a new daily cron job that runs `recalculateScores()` on a daily schedule
-3. After the daily batch completes, bulk-sync updated article scores to the Meilisearch index
+2. `server/index.ts`: Add a separate cron job that runs `recalculateScores()` on a configurable schedule
+3. After each recalculation, bulk-sync updated article scores to the Meilisearch index
 4. Do not change the `recalculateScores()` WHERE clause (use existing logic as-is)
 
-### Daily Batch Schedule
+### Schedule
 
-- Default: `0 3 * * *` (daily at 3:00 AM)
+- Default: `*/5 * * * *` (every 5 minutes, same as the original frequency)
 - Configurable via the `SCORE_RECALC_SCHEDULE` environment variable
+- For deployments where event-driven updates cover all engagement actions, set to e.g. `0 3 * * *` (daily) to reduce CPU cost
 - Document the default in `.env.example`
 
 ### Meilisearch Bulk Sync
 
-After the daily batch completes, fetch articles matching the same WHERE clause as `recalculateScores()` and bulk-sync their scores to Meilisearch. `recalculateScores()` itself is not modified; a separate sync function is added.
+After each recalculation, fetch articles matching the same WHERE clause as `recalculateScores()` and bulk-sync their scores to Meilisearch. `recalculateScores()` itself is not modified; a separate sync function is added.
 
 ```typescript
 // Daily batch flow
 const { updated } = recalculateScores()
 if (updated > 0) {
-  syncAllScoredArticlesToSearch()
+  await syncAllScoredArticlesToSearch()
 }
 ```
 
-`syncAllScoredArticlesToSearch()` is added to `server/search/sync.ts`. It queries `id, score` using the same WHERE clause as the batch and performs a partial document update in Meilisearch. Since it runs once daily, performance impact is minimal.
+`syncAllScoredArticlesToSearch()` is added to `server/search/sync.ts`. It queries `id, score` using the shared `SCORED_ARTICLES_WHERE` constant (exported from `server/db/articles.ts`) and performs batched partial document updates in Meilisearch (batch size 1000, matching `rebuildSearchIndex()`). The function is async and awaits each Meilisearch call to ensure sync completion before logging success. It skips execution if an index rebuild is in progress (the rebuild will include fresh scores).
 
 ### Key Files
 
 | File | Description |
 |---|---|
-| `server/index.ts` | Cron schedule changes |
-| `server/search/sync.ts` | `syncAllScoredArticlesToSearch()` function |
-| `.env.example` | `SCORE_RECALC_SCHEDULE` documentation |
+| `server/index.ts` | Cron schedule: removed `recalculateScores()` from feed-fetch, added separate score recalculation cron |
+| `server/search/sync.ts` | `syncAllScoredArticlesToSearch()` — batched Meilisearch score sync |
+| `server/db/articles.ts` | `SCORED_ARTICLES_WHERE` constant shared between recalculation and sync |
+| `.env.example` | `SCORE_RECALC_SCHEDULE` environment variable documentation |
 
 ### Logging
 
 Follow existing log format at `info` level:
 
 ```
-[cron] Daily score recalc: 142 articles updated
+[cron] Scores recalculated: 142 articles
 [cron] Score sync to search: 142 articles
 ```
 
@@ -122,7 +124,7 @@ Follow existing log format at `info` level:
 This spec is limited to:
 
 - Removing `recalculateScores()` from the feed-fetch cron
-- Adding a daily batch cron
+- Adding a separate score recalculation cron
 - Adding the Meilisearch bulk sync function
 
 Out of scope:
@@ -132,18 +134,18 @@ Out of scope:
 
 ### Error Handling
 
-Follow existing cron error handling: try-catch with `log.error`. No retries (the next daily batch will re-run automatically). If `recalculateScores()` errors, skip the Meilisearch sync.
+Follow existing cron error handling: try-catch with `log.error`. No retries (the next scheduled run will re-execute automatically). If `recalculateScores()` errors, skip the Meilisearch sync.
 
 ```typescript
 try {
   const { updated } = recalculateScores()
-  log.info(`[cron] Daily score recalc: ${updated} articles updated`)
+  log.info(`[cron] Scores recalculated: ${updated} articles`)
   if (updated > 0) {
-    syncAllScoredArticlesToSearch()
-    log.info(`[cron] Score sync to search: ${updated} articles`)
+    const synced = await syncAllScoredArticlesToSearch()
+    log.info(`[cron] Score sync to search: ${synced} articles`)
   }
 } catch (err) {
-  log.error('[cron] Daily score recalc error:', err)
+  log.error('[cron] Score recalculation error:', err)
 }
 ```
 
@@ -153,13 +155,11 @@ No mutex is needed between the daily batch and the feed-fetch cron. SQLite's WAL
 
 ### Migration
 
-No schema changes required. Deploy the code change only. After deployment, the next feed-fetch cron cycle will no longer run `recalculateScores()`, and the daily batch will first execute at the configured schedule time.
+No schema changes required. Deploy the code change only. After deployment, the feed-fetch cron no longer runs `recalculateScores()`, and the separate score recalculation cron takes over at the configured schedule.
 
 ## Expected Impact
 
-- Recalculation frequency reduced from every 5 minutes (288×/day) to once daily
-- CPU cost reduced by ~1/288
-- Score immediacy is maintained by event-driven updates
-- Time decay refresh is delayed by up to 24 hours, which is acceptable for an RSS reader (decay factor 0.05 means daily drift is negligible)
-- Meilisearch scores are refreshed daily
-
+- Score recalculation is decoupled from feed fetching, allowing independent schedule tuning
+- Default frequency unchanged (5 minutes); can be reduced to daily via `SCORE_RECALC_SCHEDULE=0 3 * * *` for ~288x CPU reduction
+- Meilisearch scores are synced after each recalculation (previously only during 6-hourly index rebuild)
+- `SCORED_ARTICLES_WHERE` constant eliminates duplicated WHERE clause across files

--- a/server/db/articles.ts
+++ b/server/db/articles.ts
@@ -44,6 +44,15 @@ function scoreExpr(prefix: string, opts?: { searchBoost?: boolean }): string {
   return `(${engagement} * ${decay}${boost})`
 }
 
+/** WHERE clause for articles that have engagement or a non-zero score. Shared with search sync. */
+export const SCORED_ARTICLES_WHERE = `(
+  liked_at IS NOT NULL
+  OR bookmarked_at IS NOT NULL
+  OR read_at IS NOT NULL
+  OR full_text_translated IS NOT NULL
+  OR score > 0
+)`
+
 /** Update score in DB and sync to search. Call within a transaction for atomicity. */
 function updateScoreDb(id: number): void {
   getDb().prepare(`UPDATE articles SET score = (${scoreExpr('')}) WHERE id = ?`).run(id)
@@ -62,11 +71,7 @@ export function updateScore(id: number): void {
 export function recalculateScores(): { updated: number } {
   const result = getDb().prepare(`
     UPDATE articles SET score = (${scoreExpr('')})
-    WHERE liked_at IS NOT NULL
-       OR bookmarked_at IS NOT NULL
-       OR read_at IS NOT NULL
-       OR full_text_translated IS NOT NULL
-       OR score > 0
+    WHERE ${SCORED_ARTICLES_WHERE}
   `).run()
   return { updated: result.changes }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,7 +18,7 @@ import { authRoutes } from './authRoutes.js'
 import { passkeyRoutes } from './passkeyRoutes.js'
 import { oauthRoutes } from './oauthRoutes.js'
 import { fetchAllFeeds } from './fetcher.js'
-import { rebuildSearchIndex, isSearchReady } from './search/sync.js'
+import { rebuildSearchIndex, isSearchReady, syncAllScoredArticlesToSearch } from './search/sync.js'
 
 // --- Startup guards ---
 if (process.env.AUTH_DISABLED === '1' && process.env.NODE_ENV !== 'development') {
@@ -165,16 +165,29 @@ cronTasks.push(cron.schedule(CRON_SCHEDULE, async () => {
     } catch (err) {
       log.error('[cron] Feed fetch error:', err)
     }
-    try {
-      const { updated } = recalculateScores()
-      log.info(`[cron] Scores recalculated: ${updated} articles`)
-    } catch (err) {
-      log.error('[cron] Score recalculation error:', err)
-    }
   })()
   activeFetchPromise = p
   await p
   activeFetchPromise = null
+}))
+
+// --- Score recalculation ---
+// Decoupled from feed fetch so the schedule can be tuned independently.
+// Default matches the original 5-minute interval; set SCORE_RECALC_SCHEDULE
+// to e.g. '0 3 * * *' (daily at 3 AM) if the event-driven path covers all
+// engagement actions and only time-decay refresh is needed.
+const SCORE_RECALC_SCHEDULE = process.env.SCORE_RECALC_SCHEDULE || '*/5 * * * *'
+cronTasks.push(cron.schedule(SCORE_RECALC_SCHEDULE, async () => {
+  try {
+    const { updated } = recalculateScores()
+    log.info(`[cron] Scores recalculated: ${updated} articles`)
+    if (updated > 0) {
+      const synced = await syncAllScoredArticlesToSearch()
+      log.info(`[cron] Score sync to search: ${synced} articles`)
+    }
+  } catch (err) {
+    log.error('[cron] Score recalculation error:', err)
+  }
 }))
 
 // --- Search index ---

--- a/server/search/sync.test.ts
+++ b/server/search/sync.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setupTestDb } from '../__tests__/helpers/testDb.js'
+import { getDb } from '../db/connection.js'
+
+// Mock Meilisearch client
+const mockWaitTask = vi.fn().mockResolvedValue({})
+const mockUpdateDocuments = vi.fn().mockReturnValue({ waitTask: mockWaitTask })
+vi.mock('./client.js', () => ({
+  getSearchClient: () => ({
+    index: () => ({
+      updateDocuments: mockUpdateDocuments,
+    }),
+  }),
+  ARTICLES_INDEX: 'articles',
+  ARTICLES_STAGING_INDEX: 'articles_staging',
+}))
+
+import { syncAllScoredArticlesToSearch, _setRebuilding } from './sync.js'
+
+function seedFeed(): number {
+  return getDb().prepare(
+    "INSERT INTO feeds (name, url) VALUES ('Test', 'https://example.com/feed')"
+  ).run().lastInsertRowid as number
+}
+
+function seedArticle(feedId: number, opts: { url: string; published_at?: string }): number {
+  return getDb().prepare(
+    'INSERT INTO articles (feed_id, title, url, published_at) VALUES (?, ?, ?, ?)'
+  ).run(feedId, 'Test Article', opts.url, opts.published_at ?? new Date().toISOString()).lastInsertRowid as number
+}
+
+describe('syncAllScoredArticlesToSearch', () => {
+  beforeEach(() => {
+    setupTestDb()
+    mockUpdateDocuments.mockClear()
+    mockWaitTask.mockClear()
+    _setRebuilding(false)
+  })
+
+  it('syncs articles with engagement to Meilisearch and returns count', async () => {
+    const feedId = seedFeed()
+    const id1 = seedArticle(feedId, { url: 'https://example.com/1' })
+    seedArticle(feedId, { url: 'https://example.com/2' })
+
+    getDb().prepare("UPDATE articles SET liked_at = datetime('now'), score = 10.0 WHERE id = ?").run(id1)
+
+    const synced = await syncAllScoredArticlesToSearch()
+
+    expect(synced).toBe(1)
+    expect(mockUpdateDocuments).toHaveBeenCalledTimes(1)
+    const docs = mockUpdateDocuments.mock.calls[0][0] as { id: number; score: number }[]
+    expect(docs).toHaveLength(1)
+    expect(docs[0].id).toBe(id1)
+    expect(docs[0].score).toBeGreaterThan(0)
+    expect(mockWaitTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 0 when no articles qualify', async () => {
+    const feedId = seedFeed()
+    seedArticle(feedId, { url: 'https://example.com/no-engagement' })
+
+    const synced = await syncAllScoredArticlesToSearch()
+
+    expect(synced).toBe(0)
+    expect(mockUpdateDocuments).not.toHaveBeenCalled()
+  })
+
+  it('includes articles with score > 0 but no engagement flags', async () => {
+    const feedId = seedFeed()
+    const id1 = seedArticle(feedId, { url: 'https://example.com/residual' })
+
+    getDb().prepare('UPDATE articles SET score = 5.0 WHERE id = ?').run(id1)
+
+    await syncAllScoredArticlesToSearch()
+
+    expect(mockUpdateDocuments).toHaveBeenCalledTimes(1)
+    const docs = mockUpdateDocuments.mock.calls[0][0] as { id: number; score: number }[]
+    expect(docs).toHaveLength(1)
+    expect(docs[0].id).toBe(id1)
+  })
+
+  it('syncs multiple qualifying articles in one call', async () => {
+    const feedId = seedFeed()
+    const id1 = seedArticle(feedId, { url: 'https://example.com/a' })
+    const id2 = seedArticle(feedId, { url: 'https://example.com/b' })
+    const id3 = seedArticle(feedId, { url: 'https://example.com/c' })
+
+    getDb().prepare("UPDATE articles SET liked_at = datetime('now'), score = 10.0 WHERE id = ?").run(id1)
+    getDb().prepare("UPDATE articles SET bookmarked_at = datetime('now'), score = 5.0 WHERE id = ?").run(id2)
+    getDb().prepare("UPDATE articles SET read_at = datetime('now'), score = 2.0 WHERE id = ?").run(id3)
+
+    await syncAllScoredArticlesToSearch()
+
+    expect(mockUpdateDocuments).toHaveBeenCalledTimes(1)
+    const docs = mockUpdateDocuments.mock.calls[0][0] as { id: number; score: number }[]
+    expect(docs).toHaveLength(3)
+    const ids = docs.map(d => d.id).sort()
+    expect(ids).toEqual([id1, id2, id3].sort())
+  })
+
+  it('returns 0 and skips sync when index rebuild is in progress', async () => {
+    const feedId = seedFeed()
+    const id1 = seedArticle(feedId, { url: 'https://example.com/rebuilding' })
+    getDb().prepare("UPDATE articles SET liked_at = datetime('now'), score = 10.0 WHERE id = ?").run(id1)
+
+    _setRebuilding(true)
+
+    const synced = await syncAllScoredArticlesToSearch()
+
+    expect(synced).toBe(0)
+    expect(mockUpdateDocuments).not.toHaveBeenCalled()
+  })
+
+  it('sends only id and score fields to Meilisearch', async () => {
+    const feedId = seedFeed()
+    const id1 = seedArticle(feedId, { url: 'https://example.com/fields' })
+    getDb().prepare("UPDATE articles SET liked_at = datetime('now'), score = 7.5 WHERE id = ?").run(id1)
+
+    await syncAllScoredArticlesToSearch()
+
+    const docs = mockUpdateDocuments.mock.calls[0][0] as Record<string, unknown>[]
+    expect(Object.keys(docs[0]).sort()).toEqual(['id', 'score'])
+  })
+})

--- a/server/search/sync.ts
+++ b/server/search/sync.ts
@@ -1,5 +1,6 @@
 import { getSearchClient, ARTICLES_INDEX, ARTICLES_STAGING_INDEX, type MeiliArticleDoc } from './client.js'
 import { getDb } from '../db/connection.js'
+import { SCORED_ARTICLES_WHERE } from '../db/articles.js'
 import { logger } from '../logger.js'
 
 const log = logger.child('search')
@@ -11,6 +12,11 @@ let rebuilding = false
 
 export function isSearchReady(): boolean {
   return searchReady
+}
+
+/** @internal Test-only helper to control rebuilding flag */
+export function _setRebuilding(value: boolean): void {
+  rebuilding = value
 }
 
 // --- Change log for rebuild consistency ---
@@ -205,6 +211,36 @@ export function deleteArticlesByFeedFromSearch(articleIds: number[]): void {
   } catch (err) {
     log.error('Failed to batch delete articles:', err)
   }
+}
+
+/**
+ * Bulk-sync scores for all articles that have engagement or a non-zero score.
+ * Uses the shared SCORED_ARTICLES_WHERE clause from server/db/articles.ts.
+ * Called after the daily score recalculation batch to keep Meilisearch in sync.
+ * Skips if an index rebuild is in progress (the rebuild will include fresh scores).
+ */
+export async function syncAllScoredArticlesToSearch(): Promise<number> {
+  if (rebuilding) {
+    log.info('Index rebuild in progress, skipping score sync')
+    return 0
+  }
+
+  const rows = getDb().prepare(`
+    SELECT id, score FROM articles
+    WHERE ${SCORED_ARTICLES_WHERE}
+  `).all() as { id: number; score: number }[]
+
+  if (rows.length === 0) return 0
+
+  const client = getSearchClient()
+  const index = client.index(ARTICLES_INDEX)
+
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE)
+    await index.updateDocuments(batch.map(({ id, score }) => ({ id, score }))).waitTask({ timeout: 60_000 })
+  }
+
+  return rows.length
 }
 
 export function syncArticlesByFeedToSearch(docs: MeiliArticleDoc[]): void {


### PR DESCRIPTION
## Summary

- Decouple score recalculation from the feed-fetch cron into its own independently scheduled cron job
- Add Meilisearch bulk sync after each recalculation (previously scores were only synced during the 6-hourly index rebuild)
- Extract shared `SCORED_ARTICLES_WHERE` constant to eliminate duplicated WHERE clause between `recalculateScores()` and the new sync function

## Background

`recalculateScores()` was embedded in the feed-fetch cron (`CRON_SCHEDULE`). Since event-driven updates (`updateScoreDb`) already handle all engagement changes instantly on  like/bookmark/read/translate/unseen, the cron's only remaining role is time-decay refresh. Coupling it to feed fetching had no justification.

This PR separates score recalculation into its own cron with a configurable schedule via `SCORE_RECALC_SCHEDULE` (default `*/5 * * * *`, same as before). You can reduce frequency to e.g. `0 3 * * *` (daily) if event-driven coverage is sufficient.

## Changes

- `server/index.ts` — Remove `recalculateScores()` from feed-fetch cron. Add separate score recalculation cron with `SCORE_RECALC_SCHEDULE` env var. Await `syncAllScoredArticlesToSearch()` after recalculation to keep Meilisearch in sync.
- `server/search/sync.ts` — Add `syncAllScoredArticlesToSearch()`. Async, batched (`BATCH_SIZE=1000`), awaits `waitTask`, skips during index rebuild, returns processed count.
- `server/db/articles.ts` — Extract `SCORED_ARTICLES_WHERE` constant shared by `recalculateScores()` and `syncAllScoredArticlesToSearch()`.
- `.env.example` — Document `SCORE_RECALC_SCHEDULE`.