### PR TITLE
Update article excerpt generation to strip Markdown syntax

### DIFF
--- a/docs/spec/30_ingestion.ja.md
+++ b/docs/spec/30_ingestion.ja.md
@@ -193,7 +193,8 @@ fetchFullText(articleUrl, cleanerConfig?)
 │     table系タグはHTMLのまま保持
 │
 └─ 7. excerpt生成
-      Markdownテキスト先頭200文字を抽出
+      Markdown記法（画像 `![](url)`、リンク `[text](url)` → text）を除去し、
+      プレーンテキスト先頭200文字を抽出
 ```
 
 **フェイルオープン設計**: pre-clean/post-clean は全体を try-catch で囲み、例外時は元HTML/Readability結果をそのまま使用する。クリーナーの障害で記事取り込みが止まらないことを保証する。

--- a/docs/spec/30_ingestion.md
+++ b/docs/spec/30_ingestion.md
@@ -63,7 +63,7 @@ Cron runs at 5-minute intervals (`*/5 * * * *`) and processes only feeds whose `
    a. If full_text is NULL -> HTML cleaning + Readability + Turndown for full-text retrieval
       - pre-clean -> Readability -> post-clean -> Markdown conversion (see pipeline details below)
       - Extract OGP image (og_image)
-      - Generate 200-character preview (excerpt)
+      - Generate 200-character preview (excerpt) — markdown syntax (images, links) stripped to plain text
    b. If lang is NULL -> Local language detection via CJK character ratio (no API required)
    c. New articles: INSERT INTO articles / Retry: UPDATE articles
    d. New articles: fire-and-forget async similarity detection (see [83_feature_similarity.md](./83_feature_similarity.md))

--- a/server/fetcher/contentWorker.test.ts
+++ b/server/fetcher/contentWorker.test.ts
@@ -124,4 +124,36 @@ describe('parseHtml', () => {
     const result = parseHtml({ html, articleUrl: BASE_URL })
     expect(result.excerpt!.length).toBeLessThanOrEqual(200)
   })
+
+  it('strips markdown image tags from excerpt', () => {
+    const html = makeHtml(`
+      <article>
+        <img src="https://example.com/hero.jpg" alt="hero image">
+        <p>This is the actual article text that should appear in the excerpt.
+        It contains multiple sentences to ensure Readability picks it up properly.</p>
+        <p>Second paragraph with more content for the extraction algorithm.</p>
+        <p>Third paragraph with even more text content to satisfy the length requirement.</p>
+      </article>
+    `)
+
+    const result = parseHtml({ html, articleUrl: BASE_URL })
+    expect(result.excerpt).not.toContain('![')
+    expect(result.excerpt).not.toContain('](')
+    expect(result.excerpt).toContain('actual article text')
+  })
+
+  it('strips markdown link syntax from excerpt but keeps link text', () => {
+    const html = makeHtml(`
+      <article>
+        <p><a href="https://example.com">Click here</a> to read more about this topic.
+        The article continues with enough text for Readability to extract it as main content.</p>
+        <p>Second paragraph with additional content to meet the length threshold.</p>
+        <p>Third paragraph with even more text content.</p>
+      </article>
+    `)
+
+    const result = parseHtml({ html, articleUrl: BASE_URL })
+    expect(result.excerpt).not.toContain('[Click here]')
+    expect(result.excerpt).toContain('Click here')
+  })
 })

--- a/server/fetcher/contentWorker.ts
+++ b/server/fetcher/contentWorker.ts
@@ -142,7 +142,12 @@ export function parseHtml(input: ParseHtmlInput): ParseHtmlResult {
     /\[([^\]]*(?:\n[^\]]*)+)\]\(([^)]+)\)/g,
     (_m, text, url) => `[${text.replace(/\s*\n\s*/g, ' ').trim()}](${url})`,
   )
-  const excerpt = fullText.replace(/\s+/g, ' ').trim().slice(0, 200).trim() || null
+  const excerptText = fullText
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')        // strip ![alt](url)
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')     // [text](url) → text
+    .replace(/\s+/g, ' ')
+    .trim()
+  const excerpt = excerptText.slice(0, 200).trim() || null
 
   const title = article?.title || ogTitle || htmlTitle
   return { fullText, ogImage, excerpt, title }


### PR DESCRIPTION
  ## Summary

Strip markdown image and link syntax from article excerpts so the list view shows readable text instead of raw markdown tags.

## Background

When a feed article starts with a hero image (e.g. AUTOMATON), the excerpt was generated from the raw markdown, resulting in `![](https://...)` being displayed in the article list. This is because the excerpt is the first 200 characters of the Turndown-generated markdown, which preserves image and link syntax.

before: 
<img width="723" height="436" alt="CleanShot 2026-03-19 at 21 44 33" src="https://github.com/user-attachments/assets/a187a895-599a-45a9-ba6a-8cc10067c8cd" />

after:
<img width="671" height="355" alt="CleanShot 2026-03-19 at 21 41 36" src="https://github.com/user-attachments/assets/b18c006d-2c3d-43f4-8331-cb4b67215609" />


## Changes
- Strip `![alt](url)` image tags from excerpt text
- Convert `[text](url)` link syntax to plain text (keep the link text)
- Update ingestion spec docs to reflect the new excerpt generation behavior