### PR TITLE
Improve decodeResponse portability and test coverage

### DIFF
--- a/server/fetcher/http.test.ts
+++ b/server/fetcher/http.test.ts
@@ -17,7 +17,7 @@ vi.mock('./flaresolverr.js', () => ({
   fetchViaFlareSolverr: (...args: unknown[]) => mockFetchViaFlareSolverr(...args),
 }))
 
-import { fetchHtml, USER_AGENT, DEFAULT_TIMEOUT, DISCOVERY_TIMEOUT, PROBE_TIMEOUT } from './http.js'
+import { fetchHtml, decodeResponse, USER_AGENT, DEFAULT_TIMEOUT, DISCOVERY_TIMEOUT, PROBE_TIMEOUT } from './http.js'
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -134,5 +134,83 @@ describe('fetchHtml', () => {
 
     const result = await fetchHtml('https://example.com')
     expect(result.contentType).toBe('')
+  })
+})
+
+// --- decodeResponse ---
+
+function fakeResponse(body: Uint8Array, contentType?: string): Response {
+  const headers = new Headers()
+  if (contentType) headers.set('content-type', contentType)
+  return {
+    headers,
+    text: async () => new TextDecoder('utf-8').decode(body),
+    arrayBuffer: async () => body.buffer,
+  } as Response
+}
+
+describe('decodeResponse', () => {
+  it('uses fast path for explicit UTF-8 charset', async () => {
+    const buf = new TextEncoder().encode('hello')
+    const res = fakeResponse(buf, 'text/html; charset=utf-8')
+    expect(await decodeResponse(res)).toBe('hello')
+  })
+
+  it('decodes Shift_JIS from Content-Type charset', async () => {
+    // "テスト" in Shift_JIS
+    const sjis = new Uint8Array([0x83, 0x65, 0x83, 0x58, 0x83, 0x67])
+    const res = fakeResponse(sjis, 'text/html; charset=Shift_JIS')
+    expect(await decodeResponse(res)).toBe('テスト')
+  })
+
+  it('detects charset from HTML meta tag when Content-Type has no charset', async () => {
+    const html = '<html><head><meta charset="Shift_JIS"></head><body>'
+    // Encode "テスト" with a Shift_JIS prefix
+    const metaBytes = new TextEncoder().encode(html)
+    const sjisBody = new Uint8Array([0x83, 0x65, 0x83, 0x58, 0x83, 0x67])
+    const buf = new Uint8Array(metaBytes.length + sjisBody.length)
+    buf.set(metaBytes, 0)
+    buf.set(sjisBody, metaBytes.length)
+    const res = fakeResponse(buf, 'text/html')
+    const result = await decodeResponse(res)
+    expect(result).toContain('テスト')
+  })
+
+  it('detects charset from XML encoding declaration', async () => {
+    const xmlDecl = '<?xml version="1.0" encoding="Shift_JIS"?>'
+    const declBytes = new TextEncoder().encode(xmlDecl)
+    const sjisBody = new Uint8Array([0x83, 0x65, 0x83, 0x58, 0x83, 0x67])
+    const buf = new Uint8Array(declBytes.length + sjisBody.length)
+    buf.set(declBytes, 0)
+    buf.set(sjisBody, declBytes.length)
+    const res = fakeResponse(buf, 'application/xml')
+    const result = await decodeResponse(res)
+    expect(result).toContain('テスト')
+  })
+
+  it('detects charset from http-equiv with reversed attribute order', async () => {
+    const html = '<html><head><meta content="text/html; charset=Shift_JIS" http-equiv="Content-Type"></head>'
+    const metaBytes = new TextEncoder().encode(html)
+    const sjisBody = new Uint8Array([0x83, 0x65, 0x83, 0x58, 0x83, 0x67])
+    const buf = new Uint8Array(metaBytes.length + sjisBody.length)
+    buf.set(metaBytes, 0)
+    buf.set(sjisBody, metaBytes.length)
+    const res = fakeResponse(buf, 'text/html')
+    const result = await decodeResponse(res)
+    expect(result).toContain('テスト')
+  })
+
+  it('falls back to UTF-8 for unknown charset label', async () => {
+    const html = '<html><head><meta charset="x-fake-encoding"></head><body>hello</body>'
+    const buf = new TextEncoder().encode(html)
+    const res = fakeResponse(buf, 'text/html')
+    const result = await decodeResponse(res)
+    expect(result).toContain('hello')
+  })
+
+  it('falls back to UTF-8 when no charset info is available', async () => {
+    const buf = new TextEncoder().encode('plain text')
+    const res = fakeResponse(buf)
+    expect(await decodeResponse(res)).toBe('plain text')
   })
 })

--- a/server/fetcher/http.ts
+++ b/server/fetcher/http.ts
@@ -28,9 +28,8 @@ function charsetFromContentType(ct: string): string | null {
  * Only scans ASCII-compatible portions to avoid being affected by BOM or binary headers.
  */
 function charsetFromBytes(buf: Uint8Array): string | null {
-  // Read the first 2048 bytes as ASCII (multibyte chars will be garbled,
-  // but charset declarations are in the ASCII range so this is fine)
-  const head = new TextDecoder('ascii', { fatal: false }).decode(buf.slice(0, 2048))
+  // Read the first 2048 bytes as ASCII — charset declarations are always ASCII-range
+  const head = String.fromCharCode(...buf.slice(0, 2048))
   // XML: <?xml version="1.0" encoding="Shift_JIS"?>
   const mx = head.match(/<\?xml\s[^?]*encoding\s*=\s*["']([^"']+)/i)
   if (mx) return mx[1].toLowerCase()
@@ -38,14 +37,19 @@ function charsetFromBytes(buf: Uint8Array): string | null {
   const m1 = head.match(/<meta\s[^>]*charset\s*=\s*"?([^"\s;>]+)/i)
   if (m1) return m1[1].toLowerCase()
   // HTML: <meta http-equiv="Content-Type" content="text/html; charset=EUC-JP">
+  // Also handles reversed attribute order: <meta content="...; charset=EUC-JP" http-equiv="Content-Type">
   const m2 = head.match(/<meta\s[^>]*http-equiv\s*=\s*"?Content-Type"?[^>]*content\s*=\s*"[^"]*charset=([^"\s;]+)/i)
   if (m2) return m2[1].toLowerCase()
+  const m3 = head.match(/<meta\s[^>]*content\s*=\s*"[^"]*charset=([^"\s;]+)"[^>]*http-equiv\s*=\s*"?Content-Type"?/i)
+  if (m3) return m3[1].toLowerCase()
   return null
 }
 
 /**
  * Decode response body with auto-detected encoding.
  * Priority: Content-Type charset → HTML meta charset → UTF-8 fallback
+ *
+ * The response body must not have been consumed yet (no prior .text() or .arrayBuffer() call).
  */
 export async function decodeResponse(res: Response): Promise<string> {
   const ct = res.headers.get('content-type') || ''


### PR DESCRIPTION
## Summary
Follow-up to #23 — fix portability issues and add missing unit tests for the `decodeResponse` charset detection logic.

## Background
PR #23 introduced `decodeResponse()` to fix mojibake on non-UTF-8 feeds. During review, four improvements were identified: non-portable `TextDecoder('ascii')` usage, attribute-order-dependent regex for `http-equiv` meta tags, missing precondition docs, and no unit tests for the core decoding function.

## Changes
- Replace `TextDecoder('ascii')` with `String.fromCharCode(...)` for portable byte-to-ASCII conversion (`http.ts:32`)
- Add a second regex to handle reversed `<meta content="..." http-equiv="Content-Type">` attribute order (`http.ts:43-44`)
- Document body-unconsumed precondition in `decodeResponse` docstring (`http.ts:52`)
- Add 7 unit tests covering: UTF-8 fast path, Shift_JIS via Content-Type, HTML meta charset detection, XML encoding declaration, reversed http-equiv order, unknown charset fallback, and no-charset fallback (`http.test.ts`)

## Related
- Fixes review nits from #23