### PR TITLE
Fix multibyte URL lookup returning 404

### DIFF
--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -236,6 +236,17 @@ describe('Articles', () => {
     expect(getArticleByUrl('https://nonexistent.com')).toBeUndefined()
   })
 
+  it('getArticleByUrl matches percent-encoded URL with raw Unicode lookup', () => {
+    const feed = seedFeed()
+    seedArticle(feed.id, { url: 'https://example.com/%E8%A8%98%E4%BA%8B' })
+
+    // Raw Unicode lookup should find the percent-encoded stored URL
+    const article = getArticleByUrl('https://example.com/記事')
+    expect(article).toBeDefined()
+    expect(article!.url).toBe('https://example.com/%E8%A8%98%E4%BA%8B')
+  })
+
+
   describe('getArticles filtering', () => {
     it('filters by feedId', () => {
       const feed1 = seedFeed({ url: 'https://a.com' })
@@ -529,6 +540,14 @@ describe('Articles', () => {
     ])
     expect(existing.has('https://example.com/a')).toBe(true)
     expect(existing.has('https://example.com/c')).toBe(false)
+  })
+
+  it('getExistingArticleUrls matches percent-encoded URLs with raw Unicode lookup', () => {
+    const feed = seedFeed()
+    seedArticle(feed.id, { url: 'https://example.com/%E8%A8%98%E4%BA%8B' })
+
+    const existing = getExistingArticleUrls(['https://example.com/記事'])
+    expect(existing.has('https://example.com/%E8%A8%98%E4%BA%8B')).toBe(true)
   })
 
   it('getExistingArticleUrls with empty array', () => {

--- a/server/db/articles.ts
+++ b/server/db/articles.ts
@@ -8,6 +8,11 @@ import { logger } from '../logger.js'
 
 const log = logger.child('retention')
 
+/** Normalize a URL so that raw-Unicode and percent-encoded forms compare equal. */
+function normalizeUrl(raw: string): string {
+  try { return new URL(raw).href } catch { return raw }
+}
+
 function buildMeiliDoc(id: number): MeiliArticleDoc | null {
   const row = getDb().prepare(`
     SELECT id, feed_id, category_id, title,
@@ -210,7 +215,7 @@ export function getArticleByUrl(url: string): ArticleDetail | undefined {
     FROM active_articles a
     JOIN feeds f ON a.feed_id = f.id
     WHERE a.url = ?
-  `).get(url) as ArticleDetail | undefined
+  `).get(normalizeUrl(url)) as ArticleDetail | undefined
 }
 
 export function getArticleById(id: number): ArticleDetail | undefined {
@@ -401,10 +406,11 @@ export function updateArticleContent(
 
 export function getExistingArticleUrls(urls: string[]): Set<string> {
   if (urls.length === 0) return new Set()
-  const placeholders = urls.map(() => '?').join(',')
+  const normalized = urls.map(normalizeUrl)
+  const placeholders = normalized.map(() => '?').join(',')
   const rows = getDb().prepare(
     `SELECT url FROM articles WHERE url IN (${placeholders})`,
-  ).all(...urls) as { url: string }[]
+  ).all(...normalized) as { url: string }[]
   return new Set(rows.map(r => r.url))
 }
 


### PR DESCRIPTION
## Summary

Fix article URL lookup failing when URLs contain multibyte (e.g. Japanese) characters, causing 404 errors on article detail pages.

## Background

`cleanUrl()` normalizes URLs via `new URL().toString()`, which percent-encodes non-ASCII characters before storing them in the database (e.g. `/記事` → `/%E8%A8%98%E4%BA%8B`). However, when the frontend looks up an article by URL, React Router decodes the path back to raw Unicode. The resulting `getArticleByUrl()` query uses the raw Unicode form, which doesn't match the percent-encoded form in the database — returning no result and a 404.

## Changes

- Add `normalizeUrl()` helper in `server/db/articles.ts` that canonicalizes URLs via `new URL(raw).href` before database queries
- Apply normalization in `getArticleByUrl()` and `getExistingArticleUrls()`
- Add tests verifying that raw-Unicode lookups match percent-encoded stored URLs