### PR TITLE
Publish multi-arch Docker images to GHCR

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
       - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -39,8 +43,11 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             GIT_COMMIT=${{ github.sha }}
             GIT_TAG=${{ github.ref_type == 'tag' && github.ref_name || 'unknown' }}

--- a/README.md
+++ b/README.md
@@ -187,6 +187,22 @@ See [`.env.example`](.env.example) for available environment variables. AI provi
 
 Runs anywhere Docker runs — a home NAS, a Raspberry Pi, or a cloud VM.
 
+### Using pre-built images
+
+Pre-built multi-architecture Docker images (amd64/arm64) are published to GHCR on every release:
+
+```bash
+docker pull ghcr.io/babarot/oksskolten:latest
+```
+
+To use the pre-built image instead of building locally, edit `compose.prod.yaml` and swap the `build` directive for the commented-out `image` line, then:
+
+```bash
+docker compose -f compose.yaml -f compose.prod.yaml up -d
+```
+
+### Building locally
+
 ```bash
 # Production with Cloudflare Tunnel
 docker compose -f compose.yaml -f compose.prod.yaml up --build -d

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,7 +1,10 @@
 services:
   server:
+    # Option A: Build locally (default)
     build:
       target: runtime
+    # Option B: Use pre-built image from GHCR (comment out "build" above and uncomment below)
+    # image: ghcr.io/babarot/oksskolten:latest
     command: []
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Overview
Add multi-architecture build (amd64/arm64) to the publish workflow and document pre-built image usage in README and compose.prod.yaml.

## Background
Issue #32 requested pre-built Docker images so users can deploy without local builds. The GHCR publish workflow already existed but only built for amd64, and the documentation didn't mention the images at all. arm64 support is needed for Apple Silicon Macs, Raspberry Pi, and ARM-based cloud instances (e.g. AWS Graviton).

## Changes
- **publish.yaml**: Add QEMU + Buildx setup, enable `platforms: linux/amd64,linux/arm64`, and configure GHA build cache (`cache-from`/`cache-to`)
- **compose.prod.yaml**: Add commented-out Option B (`image: ghcr.io/babarot/oksskolten:latest`) alongside the existing local build option. No change to default behavior
- **README.md**: Add "Using pre-built images" section under Deployment with `docker pull` and compose usage instructions

Closes #32