### PR TITLE
Refactor `safeFetch` to exclude certain HTTP status codes as redirects

### DIFF
--- a/server/fetcher/ssrf.test.ts
+++ b/server/fetcher/ssrf.test.ts
@@ -184,6 +184,20 @@ describe('safeFetch', () => {
     )
   })
 
+  it('passes through 304 Not Modified without treating it as a redirect', async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 304 }))
+    const res = await safeFetch('http://example.com')
+    expect(res.status).toBe(304)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes through 300 Multiple Choices without treating it as a redirect', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('choices', { status: 300 }))
+    const res = await safeFetch('http://example.com')
+    expect(res.status).toBe(300)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
   it('validates each hop in a redirect chain', async () => {
     mockFetch
       .mockResolvedValueOnce(

--- a/server/fetcher/ssrf.ts
+++ b/server/fetcher/ssrf.ts
@@ -39,13 +39,16 @@ export async function assertSafeUrl(url: string): Promise<void> {
 }
 
 const MAX_REDIRECTS = 5
+// Only actual redirect statuses per RFC 7231/7538.
+// Excludes 300 (Multiple Choices) and 304 (Not Modified).
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
 
 export async function safeFetch(url: string, init?: RequestInit): Promise<Response> {
   await assertSafeUrl(url)
   let currentUrl = url
   for (let i = 0; i < MAX_REDIRECTS; i++) {
     const res = await fetch(currentUrl, { ...init, redirect: 'manual' })
-    if (res.status >= 300 && res.status < 400) {
+    if (REDIRECT_STATUSES.has(res.status)) {
       const location = res.headers.get('location')
       if (!location) throw new Error(`Redirect without Location header from ${currentUrl}`)
       currentUrl = new URL(location, currentUrl).href


### PR DESCRIPTION
# Summary

Fix `safeFetch` treating 304 Not Modified as a redirect, which broke feed updates for any external feed that had an etag saved.

## Background

Oksskolten was missing feed updates that Feedly had no trouble picking up. Checked the production logs on my environment and found a bunch of external feeds failing with "Redirect without Location header."

`safeFetch` (`server/fetcher/ssrf.ts`) uses `redirect: 'manual'` to follow redirects one hop at a time for SSRF protection. It detected redirects with `res.status >= 300 && res.status < 400`, which includes 304 Not Modified. So when a feed returned 304 in response to `If-None-Match`, `safeFetch` looked for a `Location` header, found none, and threw. Each failure bumped `error_count`, which eventually triggered exponential backoff up to 4 hours. The feeds were still being checked, just barely.
RSS Bridge feeds were fine because they go through plain `fetch()`, not `safeFetch`. Any external feed with an etag would hit this.

## Changes

- Replace range check (`status >= 300 && status < 400`) with an explicit set of redirect statuses (301, 302, 303, 307, 308) in `safeFetch`
- Add tests for 304 and 300 passthrough