### PR TITLE
Update keyboard navigation to include prefetching on near-end items

### DIFF
--- a/docs/spec/84_feature_keyboard_navigation.md
+++ b/docs/spec/84_feature_keyboard_navigation.md
@@ -142,7 +142,13 @@ Minimal ARIA attributes are applied:
 ### Boundary Behavior
 
 - Pressing the prev key at the top of the list: no action (stays at the top)
-- Pressing the next key at the bottom of the list: no action (stays at the bottom). Does not trigger infinite scroll page loading
+- Pressing the next key at the bottom of the loaded list: no action (stays at the bottom)
+
+### Prefetch on Near-End Navigation
+
+When the user navigates with the next key and the focused article is within **5 items of the end** of the currently loaded list, the next page of articles is prefetched via `useSWRInfinite`'s `setSize`. This ensures seamless reading — new articles load before the user reaches the end, so keyboard-driven reading never hits a dead end while unread articles remain.
+
+The threshold of 5 items provides enough buffer for the fetch to complete before the user reaches the last loaded article. The `onNearEnd` callback in `useKeyboardNavigation` fires only when `has_more` is true, avoiding unnecessary requests.
 
 ### Scroll Control
 

--- a/src/components/article/article-list.tsx
+++ b/src/components/article/article-list.tsx
@@ -185,6 +185,7 @@ export const ArticleList = forwardRef<ArticleListHandle, object>(function Articl
       const article = articleMap.get(id)
       if (article?.url) window.open(article.url, '_blank')
     },
+    onNearEnd: () => loadMoreRef.current(),
     enabled: isKeyboardNavEnabled,
     keyBindings: keybindings,
   })

--- a/src/hooks/use-keyboard-navigation.ts
+++ b/src/hooks/use-keyboard-navigation.ts
@@ -14,6 +14,9 @@ export const DEFAULT_KEY_BINDINGS: KeyBindings = {
   openExternal: ';',
 }
 
+/** Number of items from the end at which onNearEnd fires */
+const NEAR_END_THRESHOLD = 5
+
 interface UseKeyboardNavigationOptions {
   items: string[]
   focusedItemId: string | null
@@ -22,6 +25,7 @@ interface UseKeyboardNavigationOptions {
   onEscape?: () => void
   onBookmarkToggle?: (id: string) => void
   onOpenExternal?: (id: string) => void
+  onNearEnd?: () => void
   enabled: boolean
   keyBindings?: KeyBindings
 }
@@ -36,7 +40,7 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions) {
     if (!options.enabled) return
 
     function handleKeyDown(e: KeyboardEvent) {
-      const { items, focusedItemId, onFocusChange, onEnter, onEscape, onBookmarkToggle, onOpenExternal, keyBindings } = optionsRef.current
+      const { items, focusedItemId, onFocusChange, onEnter, onEscape, onBookmarkToggle, onOpenExternal, onNearEnd, keyBindings } = optionsRef.current
       const bindings = keyBindings ?? DEFAULT_KEY_BINDINGS
 
       const target = e.target as HTMLElement
@@ -71,6 +75,9 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions) {
           const nextIndex = currentIndex + 1
           if (nextIndex < items.length) {
             onFocusChange(items[nextIndex])
+            if (items.length - nextIndex <= NEAR_END_THRESHOLD && onNearEnd) {
+              onNearEnd()
+            }
           }
         } else {
           const prevIndex = currentIndex - 1


### PR DESCRIPTION
## Summary

Keyboard navigation (`j` key) now prefetches the next page of articles when approaching the end of the loaded list, preventing a dead end while unread articles remain.

## Background

The inbox loads 20 articles per page via infinite scroll using IntersectionObserver. However, keyboard navigation (`j`/`k`) was bounded by the currently loaded items and did not trigger the next page load. 
Users who read through the inbox entirely via keyboard would reach the last loaded article and stop, even though more unread articles existed beyond the loaded page.

## Changes

- Add `onNearEnd` optional callback to `useKeyboardNavigation` hook, fired when `j` moves focus within 5 items of the end
- Wire `onNearEnd` to the existing `loadMore` function in `ArticleList`
- Update keyboard navigation spec to document the prefetch behavior and remove the previous "does not trigger infinite scroll" statement