### PR TITLE
Expose article original URL as data-original-url attribute on all car…

### DIFF
--- a/src/components/article/article-card.tsx
+++ b/src/components/article/article-card.tsx
@@ -119,17 +119,18 @@ function useCardBase(article: ArticleListItem, dateMode: 'relative' | 'absolute'
     void navigate(href)
   }
 
-  return { isUnread, domain, dateText, href, handleClick }
+  return { isUnread, domain, dateText, href, handleClick, originalUrl: article.url }
 }
 
 /** List layout — classic single-column (current default) */
 function ListCard({ article, dateMode, indicatorStyle, showUnreadIndicator, showThumbnails, onClick }: ArticleCardProps) {
-  const { isUnread, domain, dateText, href, handleClick } = useCardBase(article, dateMode, onClick)
+  const { isUnread, domain, dateText, href, handleClick, originalUrl } = useCardBase(article, dateMode, onClick)
   const showIndicator = isUnread && showUnreadIndicator
 
   return (
     <a
       href={href}
+      data-original-url={originalUrl}
       onClick={handleClick}
       className={`article-card block w-full text-left border-b border-border py-3 px-4 md:px-6 transition-[background-color,transform,box-shadow,border-color] duration-100 hover:bg-hover hover:-translate-y-px hover:shadow-sm select-none no-underline text-inherit ${
         indicatorStyle === 'line'
@@ -181,11 +182,12 @@ function ListCard({ article, dateMode, indicatorStyle, showUnreadIndicator, show
 
 /** Card layout — image-forward grid card */
 function GridCard({ article, dateMode, showThumbnails, onClick }: ArticleCardProps) {
-  const { isUnread, domain, dateText, href, handleClick } = useCardBase(article, dateMode, onClick)
+  const { isUnread, domain, dateText, href, handleClick, originalUrl } = useCardBase(article, dateMode, onClick)
 
   return (
     <a
       href={href}
+      data-original-url={originalUrl}
       onClick={handleClick}
       className="article-card block border border-border rounded-lg overflow-hidden transition-[background-color,transform,box-shadow] duration-100 hover:bg-hover hover:-translate-y-px hover:shadow-sm select-none no-underline text-inherit"
     >
@@ -226,11 +228,12 @@ function GridCard({ article, dateMode, showThumbnails, onClick }: ArticleCardPro
 
 /** Magazine layout — hero card (large) */
 function HeroCard({ article, dateMode, showThumbnails, onClick }: ArticleCardProps) {
-  const { isUnread, domain, dateText, href, handleClick } = useCardBase(article, dateMode, onClick)
+  const { isUnread, domain, dateText, href, handleClick, originalUrl } = useCardBase(article, dateMode, onClick)
 
   return (
     <a
       href={href}
+      data-original-url={originalUrl}
       onClick={handleClick}
       className="article-card block border border-border rounded-lg overflow-hidden transition-[background-color,transform,box-shadow] duration-100 hover:bg-hover hover:-translate-y-px hover:shadow-sm select-none no-underline text-inherit mb-4"
     >
@@ -271,11 +274,12 @@ function HeroCard({ article, dateMode, showThumbnails, onClick }: ArticleCardPro
 
 /** Magazine layout — small card (below hero) */
 function SmallCard({ article, dateMode, showThumbnails, onClick }: ArticleCardProps) {
-  const { isUnread, domain, dateText, href, handleClick } = useCardBase(article, dateMode, onClick)
+  const { isUnread, domain, dateText, href, handleClick, originalUrl } = useCardBase(article, dateMode, onClick)
 
   return (
     <a
       href={href}
+      data-original-url={originalUrl}
       onClick={handleClick}
       className="article-card flex gap-3 border-b border-border py-2 px-4 md:px-6 transition-[background-color,transform,box-shadow] duration-100 hover:bg-hover hover:-translate-y-px hover:shadow-sm select-none no-underline text-inherit"
     >
@@ -316,12 +320,13 @@ function SmallCard({ article, dateMode, showThumbnails, onClick }: ArticleCardPr
 
 /** Compact layout — title and date only */
 function CompactCard({ article, dateMode, indicatorStyle, showUnreadIndicator, onClick }: ArticleCardProps) {
-  const { isUnread, dateText, href, handleClick } = useCardBase(article, dateMode, onClick)
+  const { isUnread, dateText, href, handleClick, originalUrl } = useCardBase(article, dateMode, onClick)
   const showIndicator = isUnread && showUnreadIndicator
 
   return (
     <a
       href={href}
+      data-original-url={originalUrl}
       onClick={handleClick}
       className={`article-card block w-full text-left border-b border-border py-1.5 px-4 md:px-6 transition-[background-color,border-color] duration-100 hover:bg-hover select-none no-underline text-inherit ${
         indicatorStyle === 'line'


### PR DESCRIPTION
## Summary

- Add `data-original-url` attribute to all `a.article-card` elements so that browser extensions (e.g. FeedlyBackgroundTab) can access the original article URL without reverse-engineering the internal routing path

## Background

The `href` on article cards points to an internal route (e.g. `/example.com/article%3Fid%3D123`), not the original article URL. In my use case, I want the original article URL to be present in the DOM alongside the internal route so that external tools can access it without reverse-engineering `articleUrlToPath`.

## Changes

- `src/components/article/article-card.tsx`: Add `originalUrl` to `useCardBase()` return value and set `data-original-url={originalUrl}` on the `<a>` tag in all 5 card variants (`ListCard`, `GridCard`, `HeroCard`, `SmallCard`, `CompactCard`)