### PR TITLE
Prevent duplicate onNearEnd calls in keyboard navigation

### DIFF
--- a/src/hooks/use-keyboard-navigation.ts
+++ b/src/hooks/use-keyboard-navigation.ts
@@ -36,6 +36,14 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions) {
   const optionsRef = useRef(options)
   optionsRef.current = options
 
+  // Fire onNearEnd only once per page; reset when items grow (new page loaded).
+  const nearEndFiredRef = useRef(false)
+  const itemsLengthRef = useRef(options.items.length)
+  if (options.items.length !== itemsLengthRef.current) {
+    itemsLengthRef.current = options.items.length
+    nearEndFiredRef.current = false
+  }
+
   useEffect(() => {
     if (!options.enabled) return
 
@@ -75,7 +83,8 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions) {
           const nextIndex = currentIndex + 1
           if (nextIndex < items.length) {
             onFocusChange(items[nextIndex])
-            if (items.length - nextIndex <= NEAR_END_THRESHOLD && onNearEnd) {
+            if (items.length - nextIndex <= NEAR_END_THRESHOLD && onNearEnd && !nearEndFiredRef.current) {
+              nearEndFiredRef.current = true
               onNearEnd()
             }
           }


### PR DESCRIPTION
## Summary
Limit the `onNearEnd` callback in `useKeyboardNavigation` to fire only once per page, instead of on every `j` keypress near the end of the list.

## Background
PR #43 added `onNearEnd` prefetching for keyboard navigation, but the callback fired on every keypress within the threshold (last 5 items). The caller's `loadMore` had a `!isValidating` guard so there was no practical harm, but relying on the caller's guard for deduplication is fragile. This change makes the hook itself guarantee single invocation per page.

## Changes
- Add `nearEndFiredRef` flag that is set to `true` after `onNearEnd` fires
- Track `items.length` changes (i.e. new page loaded) to reset the flag
- `onNearEnd` now fires exactly once per page load