### PR TITLE
Add fallback mechanism for RSS description as article content

### DIFF
--- a/server/fetcher.test.ts
+++ b/server/fetcher.test.ts
@@ -1523,6 +1523,89 @@ describe('fetchSingleFeed — content extraction', () => {
     expect(row.full_text).toContain('genuine article content')
   })
 
+  it('falls back to RSS description when page extraction fails (SPA site)', async () => {
+    const feed = seedFeed()
+    // RSS with <description> containing HTML content (like Scrapbox)
+    const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>SPA Article</title>
+      <link>https://example.com/spa-article</link>
+      <description><![CDATA[<a href="https://example.com/tag">#tag</a><br /><br />This is the article content from RSS description. It has enough text to be meaningful for the reader and should be used as fallback when page extraction fails completely.]]></description>
+    </item>
+  </channel>
+</rss>`
+
+    // SPA page: content is in display:none div, empty otherwise
+    const spaHtml = `<!DOCTYPE html>
+<html>
+<head><title>SPA Article</title></head>
+<body>
+  <div id="app-container"></div>
+  <div class="summary" style="display:none">
+    <p>Hidden content that will be removed by pre-clean.</p>
+  </div>
+</body>
+</html>`
+
+    mockFetch.mockImplementation((url: string | URL) => {
+      const u = url.toString()
+      if (u === feed.rss_url) return Promise.resolve(mockResponse(rssXml, { headers: { 'content-type': 'application/rss+xml' } }))
+      if (u === 'https://example.com/spa-article') return Promise.resolve(mockResponse(spaHtml))
+      return Promise.resolve(mockResponse('', { status: 404 }))
+    })
+
+    await fetchSingleFeed(feed)
+
+    const { getDb } = await import('./db.js')
+    const row = getDb().prepare('SELECT full_text, last_error FROM articles WHERE url = ?').get('https://example.com/spa-article') as { full_text: string | null; last_error: string | null }
+    expect(row.full_text).toBeTruthy()
+    expect(row.full_text).toContain('article content from RSS description')
+    // Should be converted to Markdown (no raw HTML tags)
+    expect(row.full_text).not.toContain('<br')
+    expect(row.full_text).not.toContain('<a ')
+    // Should not have a lingering error since fallback succeeded
+    expect(row.last_error).toBeNull()
+  })
+
+  it('falls back to RSS description when extracted content is too short', async () => {
+    const feed = seedFeed()
+    const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Short Page</title>
+      <link>https://example.com/short-page</link>
+      <description><![CDATA[This is a much longer description from the RSS feed that contains meaningful article content. It discusses various topics and provides substantial information that the reader would find valuable. The content continues for several sentences to ensure it exceeds the minimum threshold.]]></description>
+    </item>
+  </channel>
+</rss>`
+
+    // Page with very minimal content
+    const shortHtml = `<!DOCTYPE html>
+<html>
+<head><title>Short Page</title></head>
+<body><article><p>Loading...</p></article></body>
+</html>`
+
+    mockFetch.mockImplementation((url: string | URL) => {
+      const u = url.toString()
+      if (u === feed.rss_url) return Promise.resolve(mockResponse(rssXml, { headers: { 'content-type': 'application/rss+xml' } }))
+      if (u === 'https://example.com/short-page') return Promise.resolve(mockResponse(shortHtml))
+      return Promise.resolve(mockResponse('', { status: 404 }))
+    })
+
+    await fetchSingleFeed(feed)
+
+    const { getDb } = await import('./db.js')
+    const row = getDb().prepare('SELECT full_text FROM articles WHERE url = ?').get('https://example.com/short-page') as { full_text: string | null }
+    expect(row.full_text).toBeTruthy()
+    expect(row.full_text).toContain('meaningful article content')
+  })
+
   it('non-Error thrown in processArticle is stringified', async () => {
     const feed = seedFeed()
     const rssXml = rss20Xml('Test', [

--- a/server/fetcher.ts
+++ b/server/fetcher.ts
@@ -16,7 +16,7 @@ import {
 import { Semaphore, CONCURRENCY, errorMessage } from './fetcher/util.js'
 import { detectAndStoreSimilarArticles } from './similarity.js'
 import { type FetchProgressEvent, emitProgress, markFeedDone } from './fetcher/progress.js'
-import { fetchFullText, isBotBlockPage } from './fetcher/content.js'
+import { fetchFullText, isBotBlockPage, convertHtmlToMarkdown, markdownToExcerpt, MIN_EXTRACTED_LENGTH } from './fetcher/content.js'
 import { type FetchRssResult, fetchAndParseRss, RateLimitError } from './fetcher/rss.js'
 import { computeInterval, computeEmpiricalInterval, sqliteFuture, DEFAULT_INTERVAL } from './fetcher/schedule.js'
 import { detectLanguage } from './fetcher/ai.js'
@@ -72,8 +72,8 @@ export async function fetchArticleContent(
     fullText = existing.full_text
     ogImage = existing.og_image
   } else if (isAnchorLink && options?.listingExcerpt) {
-    fullText = options.listingExcerpt
-    excerpt = options.listingExcerpt
+    fullText = convertHtmlToMarkdown(options.listingExcerpt)
+    excerpt = markdownToExcerpt(fullText)
   } else {
     try {
       const result = await fetchFullText(url, { requiresJsChallenge: options?.requiresJsChallenge })
@@ -86,13 +86,23 @@ export async function fetchArticleContent(
     }
   }
 
-  // Fallback: use RSS inline content when page fetch failed or returned bot-block page
+  // Fallback: use RSS inline content when page fetch failed, returned bot-block page,
+  // or extracted text is too short (e.g. SPA sites where content is in display:none for SEO).
+  // This is the last resort after fetchFullText and its internal FlareSolverr retry
+  // (which also uses MIN_EXTRACTED_LENGTH) have both failed to produce enough content.
   if (options?.listingExcerpt) {
-    const shouldFallback = !fullText || isBotBlockPage(fullText)
+    const extractedLen = fullText?.replace(/\s+/g, ' ').trim().length ?? 0
+    const shouldFallback = !fullText || isBotBlockPage(fullText) || extractedLen < MIN_EXTRACTED_LENGTH
     if (shouldFallback) {
-      fullText = options.listingExcerpt
-      excerpt = options.listingExcerpt
-      lastError = null
+      const md = convertHtmlToMarkdown(options.listingExcerpt)
+      const mdLen = md.replace(/\s+/g, ' ').trim().length
+      // Only use RSS content if it's more substantial than what we extracted
+      if (mdLen > extractedLen) {
+        log.info({ url, extractedLen, rssLen: mdLen }, 'using RSS feed content as fallback')
+        fullText = md
+        excerpt = markdownToExcerpt(md)
+        lastError = null
+      }
     }
   }
 

--- a/server/fetcher/content.test.ts
+++ b/server/fetcher/content.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { parseHtml } from './contentWorker.js'
 import { extractAnchoredContentHtml, isBotBlockPage, stripHeavyTags } from './content.js'
+import { convertHtmlToMarkdown, markdownToExcerpt } from './markdown-utils.js'
 
 // ---------------------------------------------------------------------------
 // Mocks — these mock modules used by contentWorker.ts (parseHtml)
@@ -419,5 +420,89 @@ describe('isBotBlockPage', () => {
   it('detects pattern embedded in larger HTML text', () => {
     const html = '<div class="wrapper"><h1>Security Check</h1><p>Please verify you are a human to continue browsing.</p></div>'
     expect(isBotBlockPage(html)).toBe(true)
+  })
+})
+
+describe('convertHtmlToMarkdown', () => {
+  it('converts simple HTML to markdown', () => {
+    const html = '<p>Hello world</p>'
+    const md = convertHtmlToMarkdown(html)
+    expect(md).toContain('Hello world')
+  })
+
+  it('converts links to markdown links', () => {
+    const html = '<a href="https://example.com">Example</a>'
+    const md = convertHtmlToMarkdown(html)
+    expect(md).toContain('[Example](https://example.com)')
+  })
+
+  it('converts br tags to line breaks', () => {
+    const html = 'Line one<br /><br />Line two'
+    const md = convertHtmlToMarkdown(html)
+    expect(md).toContain('Line one')
+    expect(md).toContain('Line two')
+  })
+
+  it('converts mixed HTML with links, line breaks, and nested spans', () => {
+    const html = '<a href="https://example.com/tag">#topic</a><br /><br />First paragraph text.<br /><span><span>&nbsp;</span>Second paragraph with nested spans and details.</span>'
+    const md = convertHtmlToMarkdown(html)
+    expect(md).toContain('#topic')
+    expect(md).toContain('First paragraph text.')
+    expect(md).toContain('Second paragraph')
+    expect(md).not.toContain('<span>')
+    expect(md).not.toContain('<br')
+  })
+
+  it('handles empty HTML', () => {
+    const md = convertHtmlToMarkdown('')
+    expect(md.trim()).toBe('')
+  })
+
+  it('passes through plain text without mangling', () => {
+    const text = 'This is plain text without any HTML tags.\nSecond line here.'
+    const md = convertHtmlToMarkdown(text)
+    expect(md).toBe(text)
+  })
+
+  it('passes through Markdown without escaping syntax', () => {
+    const markdown = '## Heading\n\nSome **bold** text and [a link](https://example.com).'
+    const md = convertHtmlToMarkdown(markdown)
+    expect(md).toBe(markdown)
+    expect(md).not.toContain('\\*')
+    expect(md).not.toContain('\\[')
+    expect(md).not.toContain('\\#')
+  })
+})
+
+describe('markdownToExcerpt', () => {
+  it('strips markdown images', () => {
+    const md = '![alt text](https://example.com/img.jpg) Some text after.'
+    expect(markdownToExcerpt(md)).toBe('Some text after.')
+  })
+
+  it('converts markdown links to plain text', () => {
+    const md = 'Read [this article](https://example.com) for more info.'
+    expect(markdownToExcerpt(md)).toBe('Read this article for more info.')
+  })
+
+  it('truncates to 200 characters by default', () => {
+    const md = 'A'.repeat(300)
+    const excerpt = markdownToExcerpt(md)!
+    expect(excerpt.length).toBe(200)
+  })
+
+  it('accepts custom max length', () => {
+    const md = 'A'.repeat(300)
+    const excerpt = markdownToExcerpt(md, 100)!
+    expect(excerpt.length).toBe(100)
+  })
+
+  it('returns null for empty markdown', () => {
+    expect(markdownToExcerpt('')).toBeNull()
+  })
+
+  it('collapses whitespace', () => {
+    const md = 'Line one.\n\nLine two.  Spaces.'
+    expect(markdownToExcerpt(md)).toBe('Line one. Line two. Spaces.')
   })
 })

--- a/server/fetcher/content.ts
+++ b/server/fetcher/content.ts
@@ -18,6 +18,12 @@ const pool = new Piscina({
 const WORKER_TIMEOUT_MS = 45_000
 
 /**
+ * Minimum character count for extracted article text to be considered valid.
+ * Shared between fetchFullText (FlareSolverr retry) and fetchArticleContent (RSS fallback).
+ */
+export const MIN_EXTRACTED_LENGTH = 200
+
+/**
  * Strip heavy non-content tags before passing HTML to the worker thread.
  * This runs on the main thread with simple regex (no DOM parsing), so it's fast.
  * Removes clearly non-content shells before Readability to reduce parse time.
@@ -132,7 +138,7 @@ export async function fetchFullText(articleUrl: string, options?: FetchFullTextO
 
   // Step 3: FlareSolverr fallback if extracted text is too short or looks like garbage
   const extractedLen = result.fullText.replace(/\s+/g, ' ').trim().length
-  const needsRetry = extractedLen < 200 || isGarbageExtraction(result.fullText)
+  const needsRetry = extractedLen < MIN_EXTRACTED_LENGTH || isGarbageExtraction(result.fullText)
   if (needsRetry && !requiresJsChallenge) {
     const flare = await fetchViaFlareSolverr(articleUrl, {
       waitForSelector: 'article, main, [role="main"], .post-content, .entry-content',
@@ -201,3 +207,8 @@ export function isBotBlockPage(text: string): boolean {
   ]
   return patterns.some(p => lower.includes(p))
 }
+
+// Re-export markdown utilities so existing import sites don't break.
+// These live in a separate file to avoid circular dependency: contentWorker.ts
+// imports from here, but content.ts creates the Piscina pool that loads contentWorker.ts.
+export { convertHtmlToMarkdown, markdownToExcerpt } from './markdown-utils.js'

--- a/server/fetcher/contentWorker.ts
+++ b/server/fetcher/contentWorker.ts
@@ -5,6 +5,7 @@ import pino from 'pino'
 import { preClean, postClean } from '../lib/cleaner/index.js'
 import { findBestContentBlock } from '../lib/cleaner/content-scorer.js'
 import type { CleanerConfig } from '../lib/cleaner/selectors.js'
+import { markdownToExcerpt } from './markdown-utils.js'
 
 const isDev = process.env.NODE_ENV === 'development'
 const logger = pino({
@@ -142,12 +143,7 @@ export function parseHtml(input: ParseHtmlInput): ParseHtmlResult {
     /\[([^\]]*(?:\n[^\]]*)+)\]\(([^)]+)\)/g,
     (_m, text, url) => `[${text.replace(/\s*\n\s*/g, ' ').trim()}](${url})`,
   )
-  const excerptText = fullText
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')        // strip ![alt](url)
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')     // [text](url) → text
-    .replace(/\s+/g, ' ')
-    .trim()
-  const excerpt = excerptText.slice(0, 200).trim() || null
+  const excerpt = markdownToExcerpt(fullText)
 
   const title = article?.title || ogTitle || htmlTitle
   return { fullText, ogImage, excerpt, title }

--- a/server/fetcher/markdown-utils.ts
+++ b/server/fetcher/markdown-utils.ts
@@ -1,0 +1,34 @@
+import TurndownService from 'turndown'
+
+// Lightweight Turndown instance for converting RSS HTML excerpts to Markdown.
+// Unlike the worker-thread instance in contentWorker.ts, this skips custom rules
+// (barePreBlock, table keep) because RSS descriptions are simple HTML fragments.
+const fallbackTurndown = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' })
+
+/** Check if a string contains HTML tags (not just plain text or Markdown). */
+const HTML_TAG_RE = /<[a-zA-Z][^>]*>/
+
+/**
+ * Convert RSS feed content to Markdown for use as article full_text.
+ * Detects whether the input is HTML, Markdown/plain text, and only applies
+ * Turndown conversion for HTML. Plain text and Markdown are returned as-is
+ * because Turndown would mangle them (escaping Markdown syntax, collapsing newlines).
+ */
+export function convertHtmlToMarkdown(content: string): string {
+  if (!HTML_TAG_RE.test(content)) return content
+  return fallbackTurndown.turndown(content)
+}
+
+/**
+ * Generate a plain-text excerpt from Markdown by stripping images and links.
+ * Used by both contentWorker (page extraction) and fetcher (RSS fallback).
+ */
+export function markdownToExcerpt(md: string, maxLen = 200): string | null {
+  return md
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')        // strip ![alt](url)
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')     // [text](url) → text
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLen)
+    .trim() || null
+}


### PR DESCRIPTION
## Summary

- Fall back to RSS feed content (`<description>` / `<content:encoded>`) when page-level content extraction fails or returns too little text
- Fixes "No content" display for SPA sites where article content is not available in the visible DOM

## Background

SPA sites may not have article content available in the visible DOM — for example, content may be hidden with `display: none` or rendered entirely via JavaScript. The `preClean` step removes hidden elements before Readability runs, which can leave an empty DOM with nothing to extract. This causes `full_text` to be stored as `null`, showing "No content" in the UI.

Meanwhile, the RSS feed's `<description>` or `<content:encoded>` tag often contains the article content — which readers like Feedly use to display content directly. The existing fallback path stored raw HTML as `full_text` and only triggered when content was completely absent or matched bot-block patterns.

## Changes

- `server/fetcher/markdown-utils.ts` — New file with `convertHtmlToMarkdown()` (auto-detects HTML vs plain text/Markdown, only applies Turndown for HTML) and `markdownToExcerpt()` (shared excerpt generation logic)
- `server/fetcher/content.ts` — Add `MIN_EXTRACTED_LENGTH` constant (200 chars) shared between FlareSolverr retry and RSS fallback; replace inline magic number; re-export markdown utilities from `markdown-utils.ts`
- `server/fetcher/contentWorker.ts` — Replace inline excerpt generation with `markdownToExcerpt()` imported from `markdown-utils.ts` (avoids circular dependency with `content.ts`)
- `server/fetcher.ts` — Broaden fallback condition to also trigger when extracted text is under `MIN_EXTRACTED_LENGTH`; convert RSS content to Markdown before storing; only apply fallback when RSS content is more substantial than extracted text; add structured log when fallback is used; fix anchor-link path to use `markdownToExcerpt()` for consistent excerpt format
- `server/fetcher/content.test.ts` — Add 13 unit tests for `convertHtmlToMarkdown` (HTML, plain text, Markdown passthrough) and `markdownToExcerpt` (image stripping, link conversion, truncation, empty input)
- `server/fetcher.test.ts` — Add 2 E2E tests: SPA page where Readability fails, and short extracted content replaced by longer RSS description
