### PR TITLE
Update feed items with excerpt

### DIFF
--- a/server/fetcher.ts
+++ b/server/fetcher.ts
@@ -333,6 +333,7 @@ export async function fetchAllFeeds(
               url: item.url,
               published_at: item.published_at,
               requires_js_challenge: !!feed.requires_js_challenge,
+              excerpt: item.excerpt,
             }))
 
           allTasks.push(...newItems)


### PR DESCRIPTION
## Summary
- `fetchAllFeeds` (batch path) was missing `excerpt: item.excerpt`, so RSS description fallback never triggered for SPA sites like Scrapbox
- `fetchSingleFeed` (single feed path) already had it, so the fallback only worked on manual refresh

## Background
PR #46 added a fallback mechanism that uses RSS `<description>` content when page fetching fails or returns too-short content (e.g. Scrapbox SPA pages). However, the fix was only applied to `fetchSingleFeed`. The `fetchAllFeeds` path (used by the scheduled batch job) did not pass `item.excerpt` through to `processArticle`, so the fallback condition `if (options?.listingExcerpt)` was always false.

## Changes
- `server/fetcher.ts`: Add `excerpt: item.excerpt` to the article task mapping in `fetchAllFeeds`, matching the existing behavior in `fetchSingleFeed`