### PR TITLE
Enforce ghalint and actionlint policies across all workflows

### DIFF
--- a/.ghalint.yaml
+++ b/.ghalint.yaml
@@ -1,0 +1,5 @@
+excludes:
+  # tagpr needs persist-credentials to push via the GitHub App token
+  - policy_name: checkout_persist_credentials_should_be_false
+    workflow_file_path: .github/workflows/tagpr.yaml
+    job_name: tagpr

--- a/.github/workflows/coverage-badge.yaml
+++ b/.github/workflows/coverage-badge.yaml
@@ -10,6 +10,7 @@ jobs:
   update-badges:
     name: Update Coverage Badges
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.workflow_run.conclusion == 'success'
     permissions:
       actions: read
@@ -20,10 +21,10 @@ jobs:
           SERVER=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/artifacts" --jq '[.artifacts[] | select(.name=="server-coverage")] | length')
           CLIENT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/artifacts" --jq '[.artifacts[] | select(.name=="client-coverage")] | length')
           if [[ "$SERVER" == "0" || "$CLIENT" == "0" ]]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "No coverage artifacts found (tests were likely skipped). Skipping badge update."
           else
-            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,8 +51,8 @@ jobs:
         run: |
           SERVER_PCT=$(jq '.total.lines.pct' artifacts/server/coverage-summary.json)
           CLIENT_PCT=$(jq '.total.lines.pct' artifacts/client/coverage-summary.json)
-          echo "SERVER_PCT=$SERVER_PCT" >> $GITHUB_ENV
-          echo "CLIENT_PCT=$CLIENT_PCT" >> $GITHUB_ENV
+          echo "SERVER_PCT=$SERVER_PCT" >> "$GITHUB_ENV"
+          echo "CLIENT_PCT=$CLIENT_PCT" >> "$GITHUB_ENV"
 
       - name: Update server coverage badge
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -11,11 +11,14 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Sync labels
         uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,8 +13,11 @@ jobs:
   no-japanese:
     name: No Japanese in source
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -19,6 +20,8 @@ jobs:
         platform: [linux/amd64, linux/arm64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
@@ -65,6 +68,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     permissions:
       contents: read
@@ -97,6 +101,7 @@ jobs:
 
       - run: |
           cd /tmp/digests
+          # shellcheck disable=SC2046
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "${REGISTRY}/${IMAGE_NAME}@sha256:%s " *)
         shell: bash

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -23,6 +23,9 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,12 +15,17 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       server: ${{ steps.filter.outputs.server }}
       client: ${{ steps.filter.outputs.client }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
@@ -58,9 +63,14 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.server == 'true' || needs.detect-changes.outputs.client == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -80,9 +90,16 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.server == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -117,9 +134,9 @@ jobs:
         id: check-base
         run: |
           if [ -f coverage/server-base/coverage-summary.json ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Coverage Report
@@ -135,9 +152,16 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.client == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -174,9 +198,9 @@ jobs:
         id: check-base
         run: |
           if [ -f coverage/client-base/coverage-summary.json ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Coverage Report
@@ -192,9 +216,14 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -224,6 +253,8 @@ jobs:
     if: always()
     needs: [check, server-test, client-test, lint-docs]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Check results
         run: |


### PR DESCRIPTION
## Summary

Apply ghalint and actionlint security policies to all 7 workflow files, resolving every reported violation to achieve a clean lint pass.

## Background

Following the supply-chain hardening in #52, ghalint and actionlint were run locally to audit remaining workflow security gaps. ghalint reported 30+ policy violations (missing timeout-minutes, leaked checkout credentials, missing job permissions, unrestricted App token). actionlint flagged unquoted shell variables and unintended word splitting. This PR resolves all of them.

## Changes

- **Add `timeout-minutes` to every job** — Prevent runaway builds from consuming resources indefinitely. Values are scaled by job weight (5 min for lightweight, 10–15 for tests, 30 for Docker builds).
- **Set `persist-credentials: false` on all `actions/checkout` steps** — Prevent the checkout token from persisting in git config where subsequent steps could misuse it. tagpr is excluded via `.ghalint.yaml` since it needs the token to push.
- **Add explicit `permissions` to each job in test.yaml** — Move from workflow-level-only permissions to job-level least-privilege scoping.
- **Restrict GitHub App token permissions in tagpr.yaml** — Add `permission-contents`, `permission-pull-requests`, `permission-issues` inputs to scope the generated token.
- **Fix shellcheck warnings** — Quote `$GITHUB_OUTPUT` and `$GITHUB_ENV` references. Suppress intentional word splitting with `# shellcheck disable=SC2046`.
- **Add `.ghalint.yaml`** — Exclude tagpr checkout from `persist-credentials` policy with documented reason.