### PR TITLE
Replace skip checkbox with two-phase choice flow for feed scope

### DIFF
--- a/docs/spec/20_api.md
+++ b/docs/spec/20_api.md
@@ -645,7 +645,9 @@ Response headers:
 | `name` | No | Display name (auto-uses RSS feed title or hostname if omitted) |
 | `rss_bridge_url` | No | URL when using RSSBridge |
 | `category_id` | No | Category ID |
-| `skip_rss_discovery` | No | If `true`, skip RSS auto-discovery (Steps 1–2) and go straight to LLM CSS selector inference (Step 3). Useful for subscribing to specific listing pages on sites that have a global RSS but no per-page feed. |
+| `discovered_rss_url` | No | HTTPS URL of a previously discovered RSS feed. When set, skip discovery and use this URL directly (Phase 2: user chose "whole site"). |
+| `discovered_rss_title` | No | Title of the discovered RSS feed. Used for auto-naming when `name` is omitted. |
+| `force_page_selector` | No | If `true`, skip Steps 1–2 and go straight to LLM CSS selector inference (Phase 2: user chose "this page only"). Mutually exclusive with `discovered_rss_url`. |
 
 Processing flow:
 1. Check `url` for duplicates → `409 { "error": "Feed URL already exists" }` on duplicate
@@ -673,6 +675,12 @@ data: {"type":"done","feed":{"id":1,"name":"...","rss_url":"...","rss_bridge_url
 Step names: `rss-discovery`, `flaresolverr` (conditional), `rss-bridge`, `css-selector`
 Statuses: `pending`, `running`, `done`, `skipped`
 The `flaresolverr` step is a child step of RSS discovery and is displayed hierarchically in the UI. It does not appear under normal conditions (when bot auth is not needed).
+
+**Two-phase choice flow**: When Step 1 finds an RSS feed, the server sends a `choice_needed` event and ends the SSE stream without creating a feed:
+```
+data: {"type":"choice_needed","rss_url":"https://example.com/rss","rss_title":"Example Feed"}
+```
+The frontend then presents the user with a choice: "Subscribe to the whole site" or "Subscribe to this page only". The user's choice triggers a second `POST /api/feeds` with either `discovered_rss_url`/`discovered_rss_title` or `force_page_selector: true`.
 
 ```json
 // Response (feed object from the final event):

--- a/docs/spec/20_api.md
+++ b/docs/spec/20_api.md
@@ -645,6 +645,7 @@ Response headers:
 | `name` | No | Display name (auto-uses RSS feed title or hostname if omitted) |
 | `rss_bridge_url` | No | URL when using RSSBridge |
 | `category_id` | No | Category ID |
+| `skip_rss_discovery` | No | If `true`, skip RSS auto-discovery (Steps 1–2) and go straight to LLM CSS selector inference (Step 3). Useful for subscribing to specific listing pages on sites that have a global RSS but no per-page feed. |
 
 Processing flow:
 1. Check `url` for duplicates → `409 { "error": "Feed URL already exists" }` on duplicate

--- a/docs/spec/30_ingestion.md
+++ b/docs/spec/30_ingestion.md
@@ -411,7 +411,7 @@ flowchart TD
 
 For sites where both RSS auto-discovery and RSS Bridge findfeed fail (e.g., claude.com/blog), the LLM infers CSS selectors for article links from the page HTML and automatically generates an RSS Bridge CssSelectorBridge URL.
 
-Users can also force this step by enabling the **"Skip RSS auto-discovery"** toggle in the Add Feed dialog, which bypasses Steps 1–2 entirely. This is useful when a site has a global RSS feed but no per-category or per-page feed (e.g., subscribing to a specific artist page on a music news site).
+When Step 1 discovers a global RSS feed, the user is presented with a choice: **"Subscribe to the whole site"** (uses the discovered RSS) or **"Subscribe to this page only"** (bypasses Steps 1–2 and runs LLM inference). This is useful when a site has a global RSS feed but no per-category or per-page feed (e.g., subscribing to a specific artist page on a music news site).
 
 **Activation conditions**: `RSS_BRIDGE_URL` environment variable is set, and at least one LLM provider API key is configured
 

--- a/docs/spec/30_ingestion.md
+++ b/docs/spec/30_ingestion.md
@@ -411,6 +411,8 @@ flowchart TD
 
 For sites where both RSS auto-discovery and RSS Bridge findfeed fail (e.g., claude.com/blog), the LLM infers CSS selectors for article links from the page HTML and automatically generates an RSS Bridge CssSelectorBridge URL.
 
+Users can also force this step by enabling the **"Skip RSS auto-discovery"** toggle in the Add Feed dialog, which bypasses Steps 1–2 entirely. This is useful when a site has a global RSS feed but no per-category or per-page feed (e.g., subscribing to a specific artist page on a music news site).
+
 **Activation conditions**: `RSS_BRIDGE_URL` environment variable is set, and at least one LLM provider API key is configured
 
 **Implementation file**: `server/rss-bridge.ts`

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -75,12 +75,17 @@ describe('GET /api/feeds', () => {
 })
 
 describe('POST /api/feeds', () => {
-  it('creates a feed via SSE', async () => {
+  it('creates a feed via SSE (Phase 2: discovered_rss_url)', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/feeds',
       headers: json,
-      payload: { url: 'https://blog.example.com', name: 'My Blog' },
+      payload: {
+        url: 'https://blog.example.com',
+        name: 'My Blog',
+        discovered_rss_url: 'https://blog.example.com/rss',
+        discovered_rss_title: 'My Blog',
+      },
     })
     expect(res.statusCode).toBe(200)
     expect(res.headers['content-type']).toBe('text/event-stream')

--- a/server/routes/feeds.test.ts
+++ b/server/routes/feeds.test.ts
@@ -108,7 +108,7 @@ describe('GET /api/discover-title', () => {
 // ---------------------------------------------------------------------------
 
 describe('POST /api/feeds — RSS discovery pipeline', () => {
-  it('skips RSS bridge and CSS selector when rss_url is found', async () => {
+  it('sends choice_needed when rss_url is found', async () => {
     mockDiscoverRssUrl.mockResolvedValue({ rssUrl: 'https://example.com/feed.xml', title: 'Blog' })
 
     const res = await app.inject({
@@ -119,13 +119,38 @@ describe('POST /api/feeds — RSS discovery pipeline', () => {
     })
 
     const events = parseSSE(res.body)
-    const rssBridge = events.find(e => e.step === 'rss-bridge')
-    const cssSelector = events.find(e => e.step === 'css-selector')
-    expect(rssBridge?.status).toBe('skipped')
-    expect(cssSelector?.status).toBe('skipped')
+    const choice = events.find(e => e.type === 'choice_needed') as any
+    expect(choice).toBeDefined()
+    expect(choice.rss_url).toBe('https://example.com/feed.xml')
+    expect(choice.rss_title).toBe('Blog')
 
+    // Should not create a feed or proceed to further steps
+    expect(events.find(e => e.type === 'done')).toBeUndefined()
     expect(mockQueryRssBridge).not.toHaveBeenCalled()
     expect(mockInferCssSelectorBridge).not.toHaveBeenCalled()
+  })
+
+  it('creates feed directly when discovered_rss_url is provided (Phase 2: whole site)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/feeds',
+      headers: json,
+      payload: {
+        url: 'https://example.com',
+        discovered_rss_url: 'https://example.com/feed.xml',
+        discovered_rss_title: 'Blog',
+      },
+    })
+
+    const events = parseSSE(res.body)
+    const done = events.find(e => e.type === 'done') as any
+    expect(done).toBeDefined()
+    expect(done.feed.rss_url).toBe('https://example.com/feed.xml')
+    expect(done.feed.name).toBe('Blog')
+
+    // Should not run discovery or bridge
+    expect(mockDiscoverRssUrl).not.toHaveBeenCalled()
+    expect(mockQueryRssBridge).not.toHaveBeenCalled()
   })
 
   it('falls back to RSS bridge when discovery fails', async () => {
@@ -170,14 +195,15 @@ describe('POST /api/feeds — RSS discovery pipeline', () => {
     expect(done.feed.rss_bridge_url).toBe('https://bridge.example.com/css-bridge')
   })
 
-  it('uses hostname as feed name when no name and no title', async () => {
-    mockDiscoverRssUrl.mockResolvedValue({ rssUrl: 'https://unnamed.example.com/feed', title: null })
-
+  it('uses hostname as feed name when no name and no title (Phase 2)', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/feeds',
       headers: json,
-      payload: { url: 'https://unnamed.example.com/blog' },
+      payload: {
+        url: 'https://unnamed.example.com/blog',
+        discovered_rss_url: 'https://unnamed.example.com/feed',
+      },
     })
 
     const events = parseSSE(res.body)
@@ -185,14 +211,16 @@ describe('POST /api/feeds — RSS discovery pipeline', () => {
     expect(done.feed.name).toBe('unnamed.example.com')
   })
 
-  it('uses discovered title as feed name when no name provided', async () => {
-    mockDiscoverRssUrl.mockResolvedValue({ rssUrl: 'https://example.com/feed', title: 'Discovered Title' })
-
+  it('uses discovered_rss_title as feed name when no name provided (Phase 2)', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/feeds',
       headers: json,
-      payload: { url: 'https://example.com' },
+      payload: {
+        url: 'https://example.com',
+        discovered_rss_url: 'https://example.com/feed',
+        discovered_rss_title: 'Discovered Title',
+      },
     })
 
     const events = parseSSE(res.body)
@@ -200,14 +228,17 @@ describe('POST /api/feeds — RSS discovery pipeline', () => {
     expect(done.feed.name).toBe('Discovered Title')
   })
 
-  it('prefers explicit name over discovered title', async () => {
-    mockDiscoverRssUrl.mockResolvedValue({ rssUrl: 'https://example.com/feed', title: 'Discovered' })
-
+  it('prefers explicit name over discovered_rss_title (Phase 2)', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/feeds',
       headers: json,
-      payload: { url: 'https://example.com', name: 'Custom Name' },
+      payload: {
+        url: 'https://example.com',
+        name: 'Custom Name',
+        discovered_rss_url: 'https://example.com/feed',
+        discovered_rss_title: 'Discovered',
+      },
     })
 
     const events = parseSSE(res.body)
@@ -257,14 +288,16 @@ describe('POST /api/feeds — RSS discovery pipeline', () => {
     expect(res.statusCode).toBe(400)
   })
 
-  it('fires fetchSingleFeed for feeds with rss_url', async () => {
-    mockDiscoverRssUrl.mockResolvedValue({ rssUrl: 'https://example.com/feed', title: 'Blog' })
-
+  it('fires fetchSingleFeed for feeds with rss_url (Phase 2)', async () => {
     await app.inject({
       method: 'POST',
       url: '/api/feeds',
       headers: json,
-      payload: { url: 'https://example.com' },
+      payload: {
+        url: 'https://example.com',
+        discovered_rss_url: 'https://example.com/feed',
+        discovered_rss_title: 'Blog',
+      },
     })
 
     // fetchSingleFeed is fire-and-forget, give it a tick

--- a/server/routes/feeds.ts
+++ b/server/routes/feeds.ts
@@ -37,12 +37,20 @@ const DiscoverTitleQuery = z.object({
   url: httpsUrl,
 })
 
-const CreateFeedBody = z.object({
-  url: httpsUrl,
-  name: z.string().optional(),
-  category_id: z.number().nullable().optional(),
-  skip_rss_discovery: z.boolean().optional(),
-})
+const CreateFeedBody = z
+  .object({
+    url: httpsUrl,
+    name: z.string().optional(),
+    category_id: z.number().nullable().optional(),
+    // Phase 2: user chose "whole site" — use this exact RSS URL
+    discovered_rss_url: httpsUrl.optional(),
+    discovered_rss_title: z.string().optional(),
+    // Phase 2: user chose "this page only" — skip to LLM inference
+    force_page_selector: z.boolean().optional(),
+  })
+  .refine((data) => !(data.discovered_rss_url && data.force_page_selector), {
+    message: 'discovered_rss_url and force_page_selector are mutually exclusive',
+  })
 
 const UpdateFeedBody = z.object({
   name: z.string().optional(),
@@ -94,15 +102,22 @@ export async function feedRoutes(api: FastifyInstance): Promise<void> {
         let discoveredTitle: string | null = null
         let requiresJsChallenge = false
 
-        if (body.skip_rss_discovery) {
-          // Skip RSS auto-discovery and RSS Bridge — go straight to LLM selector inference
+        if (body.discovered_rss_url) {
+          // Phase 2: user chose "whole site" — use the provided RSS URL directly
+          rssUrl = body.discovered_rss_url
+          discoveredTitle = body.discovered_rss_title ?? null
+          send({ type: 'step', step: 'rss-discovery', status: 'done', found: true })
+          send({ type: 'step', step: 'rss-bridge', status: 'skipped' })
+          send({ type: 'step', step: 'css-selector', status: 'skipped' })
+        } else if (body.force_page_selector) {
+          // Phase 2: user chose "this page only" — skip to LLM inference
           send({ type: 'step', step: 'rss-discovery', status: 'skipped' })
           send({ type: 'step', step: 'rss-bridge', status: 'skipped' })
           send({ type: 'step', step: 'css-selector', status: 'running' })
           rssBridgeUrl = await inferCssSelectorBridge(body.url)
           send({ type: 'step', step: 'css-selector', status: 'done', found: !!rssBridgeUrl })
         } else {
-          // Step 1: RSS auto-discovery
+          // Phase 1: normal discovery flow
           send({ type: 'step', step: 'rss-discovery', status: 'running' })
           try {
             const result = await discoverRssUrl(body.url, {
@@ -118,17 +133,20 @@ export async function feedRoutes(api: FastifyInstance): Promise<void> {
             send({ type: 'step', step: 'rss-discovery', status: 'done', found: false })
           }
 
-          // Step 2: RSS Bridge fallback
-          if (!rssUrl) {
-            send({ type: 'step', step: 'rss-bridge', status: 'running' })
-            rssBridgeUrl = await queryRssBridge(body.url)
-            send({ type: 'step', step: 'rss-bridge', status: 'done', found: !!rssBridgeUrl })
-          } else {
-            send({ type: 'step', step: 'rss-bridge', status: 'skipped' })
+          // If RSS found, offer a choice instead of proceeding
+          if (rssUrl) {
+            send({ type: 'choice_needed', rss_url: rssUrl, rss_title: discoveredTitle })
+            sse.end()
+            return
           }
 
+          // Step 2: RSS Bridge fallback
+          send({ type: 'step', step: 'rss-bridge', status: 'running' })
+          rssBridgeUrl = await queryRssBridge(body.url)
+          send({ type: 'step', step: 'rss-bridge', status: 'done', found: !!rssBridgeUrl })
+
           // Step 3: CssSelectorBridge via LLM
-          if (!rssUrl && !rssBridgeUrl) {
+          if (!rssBridgeUrl) {
             send({ type: 'step', step: 'css-selector', status: 'running' })
             rssBridgeUrl = await inferCssSelectorBridge(body.url)
             send({ type: 'step', step: 'css-selector', status: 'done', found: !!rssBridgeUrl })
@@ -139,7 +157,10 @@ export async function feedRoutes(api: FastifyInstance): Promise<void> {
 
         // If every strategy failed, do not create a feed.
         if (!rssUrl && !rssBridgeUrl) {
-          send({ type: 'error', error: 'RSS could not be detected for this URL' })
+          const errorMsg = body.force_page_selector
+            ? 'Could not extract content from this page'
+            : 'RSS could not be detected for this URL'
+          send({ type: 'error', error: errorMsg })
           sse.end()
           return
         }

--- a/server/routes/feeds.ts
+++ b/server/routes/feeds.ts
@@ -41,6 +41,7 @@ const CreateFeedBody = z.object({
   url: httpsUrl,
   name: z.string().optional(),
   category_id: z.number().nullable().optional(),
+  skip_rss_discovery: z.boolean().optional(),
 })
 
 const UpdateFeedBody = z.object({
@@ -93,38 +94,47 @@ export async function feedRoutes(api: FastifyInstance): Promise<void> {
         let discoveredTitle: string | null = null
         let requiresJsChallenge = false
 
-        // Step 1: RSS auto-discovery
-        send({ type: 'step', step: 'rss-discovery', status: 'running' })
-        try {
-          const result = await discoverRssUrl(body.url, {
-            onFlareSolverr: (status, found) => {
-              send({ type: 'step', step: 'flaresolverr', status: status === 'running' ? 'running' : 'done', found })
-            },
-          })
-          rssUrl = result.rssUrl
-          discoveredTitle = result.title
-          if (result.usedFlareSolverr) requiresJsChallenge = true
-          send({ type: 'step', step: 'rss-discovery', status: 'done', found: !!rssUrl })
-        } catch {
-          send({ type: 'step', step: 'rss-discovery', status: 'done', found: false })
-        }
-
-        // Step 2: RSS Bridge fallback
-        if (!rssUrl) {
-          send({ type: 'step', step: 'rss-bridge', status: 'running' })
-          rssBridgeUrl = await queryRssBridge(body.url)
-          send({ type: 'step', step: 'rss-bridge', status: 'done', found: !!rssBridgeUrl })
-        } else {
+        if (body.skip_rss_discovery) {
+          // Skip RSS auto-discovery and RSS Bridge — go straight to LLM selector inference
+          send({ type: 'step', step: 'rss-discovery', status: 'skipped' })
           send({ type: 'step', step: 'rss-bridge', status: 'skipped' })
-        }
-
-        // Step 3: CssSelectorBridge via LLM
-        if (!rssUrl && !rssBridgeUrl) {
           send({ type: 'step', step: 'css-selector', status: 'running' })
           rssBridgeUrl = await inferCssSelectorBridge(body.url)
           send({ type: 'step', step: 'css-selector', status: 'done', found: !!rssBridgeUrl })
         } else {
-          send({ type: 'step', step: 'css-selector', status: 'skipped' })
+          // Step 1: RSS auto-discovery
+          send({ type: 'step', step: 'rss-discovery', status: 'running' })
+          try {
+            const result = await discoverRssUrl(body.url, {
+              onFlareSolverr: (status, found) => {
+                send({ type: 'step', step: 'flaresolverr', status: status === 'running' ? 'running' : 'done', found })
+              },
+            })
+            rssUrl = result.rssUrl
+            discoveredTitle = result.title
+            if (result.usedFlareSolverr) requiresJsChallenge = true
+            send({ type: 'step', step: 'rss-discovery', status: 'done', found: !!rssUrl })
+          } catch {
+            send({ type: 'step', step: 'rss-discovery', status: 'done', found: false })
+          }
+
+          // Step 2: RSS Bridge fallback
+          if (!rssUrl) {
+            send({ type: 'step', step: 'rss-bridge', status: 'running' })
+            rssBridgeUrl = await queryRssBridge(body.url)
+            send({ type: 'step', step: 'rss-bridge', status: 'done', found: !!rssBridgeUrl })
+          } else {
+            send({ type: 'step', step: 'rss-bridge', status: 'skipped' })
+          }
+
+          // Step 3: CssSelectorBridge via LLM
+          if (!rssUrl && !rssBridgeUrl) {
+            send({ type: 'step', step: 'css-selector', status: 'running' })
+            rssBridgeUrl = await inferCssSelectorBridge(body.url)
+            send({ type: 'step', step: 'css-selector', status: 'done', found: !!rssBridgeUrl })
+          } else {
+            send({ type: 'step', step: 'css-selector', status: 'skipped' })
+          }
         }
 
         // If every strategy failed, do not create a feed.

--- a/src/components/feed/feed-step.tsx
+++ b/src/components/feed/feed-step.tsx
@@ -14,6 +14,7 @@ type TranslateFn = ReturnType<typeof useI18n>['t']
 /** Map raw server error messages to i18n keys so they render in the user's locale. */
 function localizeServerError(raw: string, t: TranslateFn): string {
   if (raw.includes('RSS could not be detected')) return t('modal.errorRssNotDetected')
+  if (raw.includes('Could not extract content')) return t('modal.errorPageExtract')
   if (raw.includes('already exists')) return t('modal.errorAlreadyExists')
   if (raw.includes('https://')) return t('modal.errorHttpsOnly')
   return raw || t('modal.genericError')
@@ -117,7 +118,6 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
   const [name, setName] = useState('')
   const [nameManuallySet, setNameManuallySet] = useState(false)
   const [url, setUrl] = useState('')
-  const [skipRssDiscovery, setSkipRssDiscovery] = useState(false)
   const [categoryId, setCategoryId] = useState<number | ''>('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
@@ -126,6 +126,7 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
 
   const [addingSteps, setAddingSteps] = useState<Record<StepName, StepState> | null>(null)
   const [addingDone, setAddingDone] = useState(false)
+  const [choiceNeeded, setChoiceNeeded] = useState<{ rss_url: string; rss_title: string | null } | null>(null)
 
   useEffect(() => {
     const trimmed = url.trim()
@@ -162,11 +163,12 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
     }
   }, [url, nameManuallySet])
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
+  async function handleSubmit(e?: React.FormEvent, phase2?: Record<string, unknown>) {
+    e?.preventDefault()
     if (!url.trim()) return
     setError('')
     setLoading(true)
+    setChoiceNeeded(null)
 
     const initSteps: Record<StepName, StepState> = {
       'rss-discovery': { status: 'pending' },
@@ -185,7 +187,7 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
           name: name.trim() || undefined,
           url: url.trim(),
           category_id: categoryId || null,
-          skip_rss_discovery: skipRssDiscovery || undefined,
+          ...phase2,
         }),
       })
 
@@ -233,6 +235,13 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
               ...prev,
               [stepName]: { status, found },
             } : prev)
+          } else if (payload.type === 'choice_needed') {
+            setChoiceNeeded({
+              rss_url: payload.rss_url as string,
+              rss_title: (payload.rss_title as string | null) ?? null,
+            })
+            setAddingSteps(null)
+            setLoading(false)
           } else if (payload.type === 'done') {
             setAddingDone(true)
             const feed = payload.feed as { id: number; rss_url: string | null; rss_bridge_url: string | null }
@@ -252,6 +261,35 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
       setError(localizeServerError(raw, t))
       setLoading(false)
     }
+  }
+
+  if (choiceNeeded) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-text">{t('modal.choiceTitle')}</p>
+        {choiceNeeded.rss_title && (
+          <p className="text-sm text-muted truncate">&ldquo;{choiceNeeded.rss_title}&rdquo;</p>
+        )}
+        <div className="flex gap-2">
+          <Button
+            className="flex-1"
+            onClick={() => handleSubmit(undefined, {
+              discovered_rss_url: choiceNeeded.rss_url,
+              discovered_rss_title: choiceNeeded.rss_title ?? undefined,
+            })}
+          >
+            {t('modal.choiceWholeSite')}
+          </Button>
+          <Button
+            variant="outline"
+            className="flex-1"
+            onClick={() => handleSubmit(undefined, { force_page_selector: true })}
+          >
+            {t('modal.choiceThisPage')}
+          </Button>
+        </div>
+      </div>
+    )
   }
 
   if (addingSteps) {
@@ -303,15 +341,6 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
           </SelectContent>
         </Select>
       )}
-      <label className="flex items-center gap-2 text-xs text-muted cursor-pointer select-none">
-        <input
-          type="checkbox"
-          checked={skipRssDiscovery}
-          onChange={e => setSkipRssDiscovery(e.target.checked)}
-          className="accent-accent"
-        />
-        {t('modal.skipRssDiscovery')}
-      </label>
       {error && <p className="text-xs text-error">{error}</p>}
       <div className="flex justify-end gap-2">
         <Button variant="outline" onClick={onClose}>

--- a/src/components/feed/feed-step.tsx
+++ b/src/components/feed/feed-step.tsx
@@ -117,6 +117,7 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
   const [name, setName] = useState('')
   const [nameManuallySet, setNameManuallySet] = useState(false)
   const [url, setUrl] = useState('')
+  const [skipRssDiscovery, setSkipRssDiscovery] = useState(false)
   const [categoryId, setCategoryId] = useState<number | ''>('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
@@ -184,6 +185,7 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
           name: name.trim() || undefined,
           url: url.trim(),
           category_id: categoryId || null,
+          skip_rss_discovery: skipRssDiscovery || undefined,
         }),
       })
 
@@ -301,6 +303,15 @@ export function FeedStep({ onClose, onCreated, onFetchStarted, categories }: Fee
           </SelectContent>
         </Select>
       )}
+      <label className="flex items-center gap-2 text-xs text-muted cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={skipRssDiscovery}
+          onChange={e => setSkipRssDiscovery(e.target.checked)}
+          className="accent-accent"
+        />
+        {t('modal.skipRssDiscovery')}
+      </label>
       {error && <p className="text-xs text-error">{error}</p>}
       <div className="flex justify-end gap-2">
         <Button variant="outline" onClick={onClose}>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -180,7 +180,10 @@ const dict = {
   'modal.step.found': { ja: '検出', en: 'Found' },
   'modal.step.notFound': { ja: 'この段階では未検出', en: 'Not detected at this step' },
   'modal.step.skipped': { ja: 'スキップ', en: 'Skipped' },
-  'modal.skipRssDiscovery': { ja: 'RSS自動検出をスキップ（LLMセレクター推論を使用）', en: 'Skip RSS auto-discovery (use LLM selector inference)' },
+  'modal.choiceTitle': { ja: 'サイト全体のRSSフィードが見つかりました', en: 'Found a site-wide RSS feed' },
+  'modal.choiceWholeSite': { ja: 'サイト全体を購読', en: 'Subscribe to the whole site' },
+  'modal.choiceThisPage': { ja: 'このページだけを購読', en: 'Subscribe to this page only' },
+  'modal.errorPageExtract': { ja: 'このページからコンテンツを抽出できませんでした', en: 'Could not extract content from this page' },
 
   // Settings
   'feeds.dateFormat': { ja: '日付表示', en: 'Date' },

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -180,6 +180,7 @@ const dict = {
   'modal.step.found': { ja: '検出', en: 'Found' },
   'modal.step.notFound': { ja: 'この段階では未検出', en: 'Not detected at this step' },
   'modal.step.skipped': { ja: 'スキップ', en: 'Skipped' },
+  'modal.skipRssDiscovery': { ja: 'RSS自動検出をスキップ（LLMセレクター推論を使用）', en: 'Skip RSS auto-discovery (use LLM selector inference)' },
 
   // Settings
   'feeds.dateFormat': { ja: '日付表示', en: 'Date' },


### PR DESCRIPTION
## Summary
When RSS auto-discovery finds a site-wide feed, present users with an intuitive choice instead of immediately subscribing:
- **"Subscribe to the whole site"** — uses the discovered RSS feed
- **"Subscribe to this page only"** — skips RSS and runs LLM CSS selector inference

This replaces the original "Skip RSS auto-discovery" checkbox, which exposed internal terminology that users wouldn't understand.

## Background
When adding a URL like an artist page (e.g., `natalie.mu/music/news/list/artist_id/9653`), sites may have a global RSS feed but no per-category or per-page feed. The previous approach added a technical checkbox to skip RSS detection, but this required users to understand the internal discovery pipeline. The new design follows an Apple-like philosophy: run discovery first, then let users choose in plain language.

Closes #41

## Changes
- **Backend** (`server/routes/feeds.ts`): Two-phase flow — Phase 1 sends `choice_needed` SSE event when RSS is found (without creating a feed); Phase 2 accepts `discovered_rss_url`/`discovered_rss_title` (whole site) or `force_page_selector` (this page only) to complete feed creation. Mutually exclusive validation via zod `.refine()`. SSRF-safe: `discovered_rss_url` reuses the `httpsUrl` validator.
- **Frontend** (`src/components/feed/feed-step.tsx`): Removed checkbox. Added `choice_needed` SSE handler that transitions to a choice prompt with two buttons. Phase 2 request preserves all original form fields (name, category_id).
- **i18n** (`src/lib/i18n.ts`): Replaced `modal.skipRssDiscovery` with `modal.choiceTitle`, `modal.choiceWholeSite`, `modal.choiceThisPage`, `modal.errorPageExtract`.
- **Docs** (`docs/spec/20_api.md`, `docs/spec/30_ingestion.md`): Documented new API parameters, `choice_needed` SSE event, and two-phase choice flow.
- **Tests**: Updated to verify `choice_needed` event on RSS discovery, Phase 2 feed creation with `discovered_rss_url`, and feed naming behavior.

## State machine
```
form → submitting(phase1) → choice_prompt → submitting(phase2) → done
                           ↘ (no RSS found) ────────────────────→ done
```

## Note
Testing with the example URL from #41 (`natalie.mu/music/news/list/artist_id/9653`) shows that RSS auto-discovery does not detect a global feed for this site — the flow falls through to LLM inference directly and works correctly. The `choice_needed` flow is designed for sites where a sub-page URL triggers global RSS detection. We've [asked the issue reporter](https://github.com/babarot/oksskolten/issues/41#issuecomment-4188425521) for a URL that reproduces the original problem.