### PR TITLE
Reduce memory usage on production server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ FROM deps AS build
 COPY . .
 RUN npm run build
 
+FROM deps AS build-server
+
+COPY . .
+RUN npm run build && npm run build:server
+
 FROM base AS runtime
 
 ARG GIT_COMMIT=unknown
@@ -44,3 +49,28 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
 CMD ["npx", "tsx", "--dns-result-order=ipv4first", "server/index.ts"]
+
+FROM base AS runtime-compiled
+
+ARG GIT_COMMIT=unknown
+ARG GIT_TAG=unknown
+ARG BUILD_DATE=unknown
+ENV GIT_COMMIT=${GIT_COMMIT}
+ENV GIT_TAG=${GIT_TAG}
+ENV BUILD_DATE=${BUILD_DATE}
+
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+COPY --from=build-server /app/dist-server ./dist-server
+COPY --from=build-server /app/dist ./dist-server/dist
+COPY --from=build-server /app/migrations ./dist-server/migrations
+
+RUN addgroup --system app && adduser --system --ingroup app app \
+ && mkdir -p /app/data && chown app:app /app/data
+USER app
+
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:3000/api/health || exit 1
+CMD ["node", "--dns-result-order=ipv4first", "dist-server/server/index.js"]

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -2,7 +2,7 @@ services:
   server:
     # Option A: Build locally (default)
     build:
-      target: runtime
+      target: runtime-compiled
     # Option B: Use pre-built image from GHCR (comment out "build" above and uncomment below)
     # image: ghcr.io/babarot/oksskolten:latest
     command: []

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:server:noauth": "NODE_ENV=development AUTH_DISABLED=1 tsx watch --env-file-if-exists=.env server/index.ts",
     "generate-pwa-assets": "pwa-assets-generator",
     "build": "vite build",
+    "build:server": "tsc -p tsconfig.server.json",
     "start": "tsx --env-file-if-exists=.env server/index.ts",
     "lint": "eslint src/ server/ shared/",
     "typecheck": "tsc --noEmit",

--- a/server/fetcher/content.ts
+++ b/server/fetcher/content.ts
@@ -7,10 +7,11 @@ import type { ParseHtmlInput, ParseHtmlResult } from './contentWorker.js'
 
 // Worker pool for CPU-intensive DOM parsing (jsdom + Readability + Turndown).
 // Runs on separate threads so the main event loop stays responsive for API requests.
-// Inherit the parent's execArgv so the tsx TypeScript loader is available in workers.
+// In development, inherit the parent's execArgv so the tsx loader is available in workers.
+const isDev = process.env.NODE_ENV === 'development'
 const pool = new Piscina({
-  filename: new URL('./contentWorker.ts', import.meta.url).href,
-  execArgv: process.execArgv,
+  filename: new URL(`./contentWorker.${isDev ? 'ts' : 'js'}`, import.meta.url).href,
+  execArgv: isDev ? process.execArgv : [],
   maxThreads: Number(process.env.PARSE_MAX_THREADS) || 2,
 })
 

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": false,
+    "outDir": "dist-server",
+    "rootDir": ".",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["server", "shared"]
+}


### PR DESCRIPTION
## Summary

Reduce memory consumption by compiling to JS.

This change is assisted by LLM coding agent but manually reviewed and tested.

## Background

I noticed the server (in production mode) memory consumption is a bit high (~400MB) with zero feed. After this change the memory consumption is reduced to ~200MB with zero feed.

## Changes

- compile the backend TypeScript ahead of time to avoid `tsx` overhead
- run plain node against emitted JavaScript instead
- add dockerfile build stages
