### PR TITLE
fix: add type="button" to cancel button in FolderStep

### DIFF
--- a/src/components/feed/folder-step.tsx
+++ b/src/components/feed/folder-step.tsx
@@ -48,7 +48,7 @@ export function FolderStep({ onClose, onCategoryCreated }: FolderStepProps) {
       />
       {error && <p className="text-xs text-error">{error}</p>}
       <div className="flex justify-end gap-2">
-        <Button variant="outline" onClick={onClose}>
+        <Button type="button" variant="outline" onClick={onClose}>
           {t('modal.cancel')}
         </Button>
         <Button type="submit" disabled={loading}>


### PR DESCRIPTION
## What was happening

Clicking **Cancel** in the "Add Folder" modal was silently swallowing the action — the modal closed without creating a category, and no error was shown. Users could rarely create a category on the first try, but subsequent attempts always failed.

## Root cause

The Cancel button in `FolderStep` had no explicit `type` attribute:

```tsx
<Button variant="outline" onClick={onClose}>
  {t('modal.cancel')}
</Button>
```

Per the HTML spec, `<button>` elements inside a `<form>` default to `type="submit"`. So clicking Cancel was triggering the form's `onSubmit` handler. Inside `handleSubmit`, the name field was empty at that point (or the event arrived before the submit button), causing an early `return` — the `POST /api/categories` call was never made, and `onCategoryCreated` was never called. The modal closed via `onClose()` with no visible feedback.

## Fix

Add `type="button"` to the Cancel button so it no longer submits the form.

```tsx
<Button type="button" variant="outline" onClick={onClose}>
  {t('modal.cancel')}
</Button>
```

## Testing

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (125 test files, 2047 tests passed)
- Manually verified: Cancel closes the modal without making any API request; Create submits `POST /api/categories` and returns 200