### PR TITLE
Fix article lists not refreshing after bookmark/like toggle

### DIFF
--- a/src/hooks/use-article-actions.ts
+++ b/src/hooks/use-article-actions.ts
@@ -6,7 +6,7 @@ import type { ArticleDetail } from '../../shared/types'
 
 export function useArticleActions(article: ArticleDetail | undefined, articleKey: string) {
   const navigate = useNavigate()
-  const { mutate: globalMutate } = useSWRConfig()
+  const { mutate: globalMutate, cache } = useSWRConfig()
 
   const [optimisticBookmark, setOptimisticBookmark] = useState<boolean | undefined>(undefined)
   const [optimisticLiked, setOptimisticLiked] = useState<string | null | undefined>(undefined)
@@ -23,13 +23,16 @@ export function useArticleActions(article: ArticleDetail | undefined, articleKey
   }, [article?.id])
 
   const revalidateLists = useCallback(() => {
-    void globalMutate((key: string) =>
-      typeof key === 'string' && (
-        key.includes('/api/feeds') ||
-        key.includes('/api/articles')
-      ),
-    )
-  }, [globalMutate])
+    // globalMutate(filterFn) silently skips $inf$ keys produced by
+    // useSWRInfinite, so walk the cache directly to cover both
+    // /api/feeds (regular) and /api/articles (infinite) entries.
+    for (const key of cache.keys()) {
+      if (typeof key !== 'string') continue
+      if (key.includes('/api/feeds') || key.includes('/api/articles')) {
+        void globalMutate(key)
+      }
+    }
+  }, [globalMutate, cache])
 
   const toggleBookmark = useCallback(async () => {
     if (!article) return


### PR DESCRIPTION
## Summary
Fix the issue where toggling bookmark or like on an article does not refresh the article lists (Inbox, Bookmarks, Liked, History, Clips) until the page is reloaded. Closes #72.

## Background
`useArticleActions` revalidated affected lists via `globalMutate(filterFn)` matching `/api/feeds` and `/api/articles`. SWR's filter-based `mutate` silently skips cache entries whose keys start with `$inf$`, which is the prefix `useSWRInfinite` uses internally. Every article list in this app is rendered with `useSWRInfinite`, so none of those entries were ever revalidated and the lists kept showing the pre-toggle state until a full page reload kicked SWR back into sync.

The wider fixes proposed in the issue (a `cache: 'no-store'` helper for `/api/feeds`, and `revalidateIfStale: true` on collection views) are intentionally not adopted. The service worker already uses NetworkFirst for `/api/*`, so a bespoke no-store fetch is redundant. Flipping `revalidateIfStale: true` on collection views would mask the root cause and add unnecessary network calls; the global `revalidateIfStale: false` setting is an intentional choice we want to preserve.

## Changes
Switch `revalidateLists` in `src/hooks/use-article-actions.ts` from a filter-based `globalMutate` to walking `cache.keys()` and mutating each matching key directly. This makes both `/api/feeds` (regular `useSWR`) and `/api/articles` (`useSWRInfinite`, stored under `$inf$...`) revalidate as expected. A short comment is added explaining why the cache walk is needed. Verified via `npm run typecheck`, `npm run lint`, and the relevant `src/hooks` / `src/components/article` vitest suites; all pass. UI smoke testing on a real browser is recommended: toggle bookmark/like from a detail view and confirm the matching list reflects the change without a reload.