### PR TITLE
Refresh cloud LLM model list to latest releases

### DIFF
--- a/shared/models.ts
+++ b/shared/models.ts
@@ -13,9 +13,11 @@ export const ANTHROPIC_MODELS: ModelGroup[] = [
   { group: 'Latest', models: [
     { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', pricing: [1, 5] },
     { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6', pricing: [3, 15] },
-    { value: 'claude-opus-4-6', label: 'Opus 4.6', pricing: [5, 25] },
+    { value: 'claude-opus-4-8', label: 'Opus 4.8', pricing: [5, 25] },
+    { value: 'claude-opus-4-7', label: 'Opus 4.7', pricing: [5, 25] },
   ]},
   { group: 'Legacy', models: [
+    { value: 'claude-opus-4-6', label: 'Opus 4.6', pricing: [5, 25] },
     { value: 'claude-sonnet-4-5-20250929', label: 'Sonnet 4.5', pricing: [3, 15] },
     { value: 'claude-opus-4-5-20251101', label: 'Opus 4.5', pricing: [5, 25] },
     { value: 'claude-sonnet-4-20250514', label: 'Sonnet 4', pricing: [3, 15] },
@@ -25,7 +27,9 @@ export const ANTHROPIC_MODELS: ModelGroup[] = [
 
 export const GEMINI_MODELS: ModelGroup[] = [
   { group: 'Latest', models: [
-    { value: 'gemini-3.1-flash-lite-preview', label: 'Gemini 3.1 Flash-Lite', pricing: [0.25, 1.50] },
+    { value: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', pricing: [1.50, 9] },
+    { value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro', pricing: [2, 12] },
+    { value: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash-Lite', pricing: [0.25, 1.50] },
   ]},
   { group: 'Standard', models: [
     { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', pricing: [0.15, 0.60] },
@@ -38,12 +42,15 @@ export const GEMINI_MODELS: ModelGroup[] = [
 
 export const OPENAI_MODELS: ModelGroup[] = [
   { group: 'Latest', models: [
+    { value: 'gpt-5.5', label: 'GPT-5.5', pricing: [5, 30] },
     { value: 'gpt-5.4', label: 'GPT-5.4', pricing: [2.50, 15] },
+    { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini', pricing: [0.75, 4.50] },
+    { value: 'gpt-5.4-nano', label: 'GPT-5.4 Nano', pricing: [0.20, 1.25] },
+  ]},
+  { group: 'Standard', models: [
     { value: 'gpt-5.3', label: 'GPT-5.3', pricing: [1.75, 14] },
     { value: 'gpt-5-mini', label: 'GPT-5 Mini', pricing: [0.25, 2] },
     { value: 'gpt-5-nano', label: 'GPT-5 Nano', pricing: [0.05, 0.40] },
-  ]},
-  { group: 'Standard', models: [
     { value: 'gpt-4.1', label: 'GPT-4.1', pricing: [2, 8] },
     { value: 'gpt-4.1-mini', label: 'GPT-4.1 Mini', pricing: [0.40, 1.60] },
     { value: 'gpt-4.1-nano', label: 'GPT-4.1 Nano', pricing: [0.10, 0.40] },


### PR DESCRIPTION
## Summary
Update `shared/models.ts` to surface the newest cloud LLM model IDs (Anthropic Opus 4.7/4.8, OpenAI GPT-5.5 plus GPT-5.4 mini/nano, Gemini 3.5 Flash and Gemini 3.1 Pro Preview) so they become selectable from the Settings UI.

## Background
The hardcoded model registry in `shared/models.ts` had drifted from upstream provider releases. Opus 4.8 (May 2026) and Opus 4.7 (April 2026) shipped on Anthropic, GPT-5.5 became OpenAI's new flagship alongside the GPT-5.4 mini/nano variants, and Google released Gemini 3.5 Flash plus the Gemini 3.1 Pro preview. Without listing these IDs the settings allowlist returned by `getModelValues()` rejects them, so users can't pick the current generation even though the LLM adapters accept arbitrary model strings.

## Changes
- Anthropic Latest: add `claude-opus-4-8` and `claude-opus-4-7` ($5 / $25 per MTok); demote `claude-opus-4-6` to Legacy.
- OpenAI Latest: add `gpt-5.5` ($5 / $30), `gpt-5.4-mini` ($0.75 / $4.50), and `gpt-5.4-nano` ($0.20 / $1.25); move GPT-5.3, the GPT-5 mini/nano pair, and the GPT-4.1 family into the Standard group.
- Gemini Latest: add `gemini-3.5-flash` ($1.50 / $9) and `gemini-3.1-pro-preview` ($2 / $12); rename the preview ID `gemini-3.1-flash-lite-preview` to the stable `gemini-3.1-flash-lite`.
- Pricing data sourced from each provider's official pricing page; group ordering preserved so the UI keeps grouping by recency. Model IDs referenced by `DEFAULT_MODELS`, `TASK_DEFAULTS`, `SUB_AGENT_MODELS`, and the test suite (haiku-4-5, sonnet-4-6, gpt-5-nano, gpt-4o, gemini-2.0-flash, gemini-2.5-flash) remain in the list, so defaults and tests are unaffected. `npm run typecheck`, `npm run lint`, and the shared/settings tests all pass locally.