### PR TITLE
fix: address production memory instability — tsx→node, worker idleTimeout, SQLite soft_heap_limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-server/
 /data/
 /data-prod/
 docs/temp_*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 FROM deps AS build
 
 COPY . .
-RUN npm run build
+RUN npm run build && npx tsc -p server/tsconfig.build.json
 
 FROM base AS runtime
 
@@ -32,6 +32,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev
 COPY --from=build /app/dist ./dist
+# Pre-compiled server — runs from dist/server/ (no tsx needed at runtime)
 COPY server ./server
 COPY shared ./shared
 COPY migrations ./migrations
@@ -43,4 +44,4 @@ USER app
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
-CMD ["npx", "tsx", "--dns-result-order=ipv4first", "server/index.ts"]
+CMD ["node", "--dns-result-order=ipv4first", "dist/server/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev
 COPY --from=build /app/dist ./dist
-# Pre-compiled server — runs from dist/server/ (no tsx needed at runtime)
-COPY server ./server
-COPY shared ./shared
+COPY --from=build /app/dist-server ./dist-server
 COPY migrations ./migrations
 
 RUN addgroup --system app && adduser --system --ingroup app app \
@@ -44,4 +42,4 @@ USER app
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
-CMD ["node", "--dns-result-order=ipv4first", "dist/server/index.js"]
+CMD ["node", "--dns-result-order=ipv4first", "dist-server/server/index.js"]

--- a/server/__tests__/setup.ts
+++ b/server/__tests__/setup.ts
@@ -13,7 +13,7 @@ vi.mock('node:dns/promises', () => ({
 // only resolve at runtime with the tsx loader.
 vi.mock('piscina', () => {
   return {
-    default: class MockPiscina {
+    Piscina: class MockPiscina {
       private handler: ((input: unknown) => unknown) | null = null
       private _loadPromise: Promise<void>
       constructor(opts: { filename: string }) {

--- a/server/db/connection.ts
+++ b/server/db/connection.ts
@@ -33,7 +33,28 @@ function openDb(dbUrl: string) {
     instance.pragma('journal_mode = WAL')
   }
   instance.pragma('foreign_keys = ON')
+  // Limit SQLite internal heap growth to prevent native memory accumulation.
+  // Soft limit: SQLite tries to stay under this; exceeding it won't cause errors.
+  instance.pragma('soft_heap_limit = 268435456')  // 256MB
   return instance
+}
+
+/**
+ * Shrink SQLite memory and checkpoint WAL to release accumulated native heap.
+ * Safe to call periodically (e.g. every 5 min) to prevent libsql RSS growth.
+ * For remote (Turso) databases, only shrink_memory is attempted.
+ */
+export function shrinkMemory() {
+  try {
+    const remote = isRemote(process.env.DATABASE_URL || '')
+    if (!remote) {
+      db.pragma('wal_checkpoint(TRUNCATE)')
+    }
+    db.pragma('shrink_memory')
+    log.info('[db] Memory shrunk' + (remote ? '' : ' + WAL checkpoint'))
+  } catch (err) {
+    log.error('[db] shrinkMemory error:', err)
+  }
 }
 
 let db = openDb(process.env.DATABASE_URL || `file:${dataPath('rss.db')}`)

--- a/server/db/connection.ts
+++ b/server/db/connection.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import Database from 'libsql'
 import { logger } from '../logger.js'
 import { dataPath } from '../paths.js'
+import { findProjectRoot } from '../paths.js'
 
 const log = logger.child('db')
 
@@ -76,7 +77,7 @@ export function allNamed<T>(sql: string, params: Record<string, unknown>) {
 // --- Migrations ---
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const projectRoot = path.resolve(__dirname, '../..')
+const projectRoot = findProjectRoot(__dirname)
 
 /** Error messages from SQLite that indicate an already-applied schema change. */
 const IDEMPOTENT_ERRORS = ['duplicate column name', 'no such column', 'already exists'] as const

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1,4 +1,4 @@
-export { getDb, _resetDb, runMigrations, bindNamedParams, runNamed, getNamed, allNamed } from './connection.js'
+export { getDb, _resetDb, runMigrations, bindNamedParams, runNamed, getNamed, allNamed, shrinkMemory } from './connection.js'
 export type { Category, Feed, FeedWithCounts, Article, ArticleListItem, ArticleDetail, Conversation, ChatMessage } from './types.js'
 export { getFeeds, getFeedById, getFeedByUrl, getEnabledFeeds, ensureClipFeed, getClipFeed, createFeed, updateFeed, deleteFeed, bulkMoveFeedsToCategory, updateFeedError, updateFeedRateLimit, updateFeedRssUrl, updateFeedCacheHeaders, updateFeedSchedule, getFeedMetrics } from './feeds.js'
 export { getArticles, getArticleByUrl, getArticleById, getArticlesByIds, markArticleSeen, markArticlesSeen, markAllSeenByFeed, markArticleBookmarked, getBookmarkCount, markArticleLiked, getLikeCount, recordArticleRead, insertArticle, updateArticleContent, getExistingArticleUrls, getRetryArticles, getRetryStats, searchArticles, getReadingStats, markImagesArchived, clearImagesArchived, deleteArticle, updateScore, recalculateScores, getRetentionStats, purgeExpiredArticles } from './articles.js'

--- a/server/fetcher/content.ts
+++ b/server/fetcher/content.ts
@@ -1,4 +1,4 @@
-import Piscina from 'piscina'
+import { Piscina as PiscinaPool } from 'piscina'
 import { JSDOM } from 'jsdom'
 import { fetchHtml } from './http.js'
 import { fetchViaFlareSolverr } from './flaresolverr.js'
@@ -8,8 +8,11 @@ import type { ParseHtmlInput, ParseHtmlResult } from './contentWorker.js'
 // Worker pool for CPU-intensive DOM parsing (jsdom + Readability + Turndown).
 // Runs on separate threads so the main event loop stays responsive for API requests.
 // Inherit the parent's execArgv so the tsx TypeScript loader is available in workers.
-const pool = new Piscina({
-  filename: new URL('./contentWorker.ts', import.meta.url).href,
+// Always reference .js — tsx resolves .js → .ts transparently during development;
+// compiled .js files exist in dist/ for production. Resolves at the build layer
+// rather than with a runtime branch.
+const pool = new PiscinaPool({
+  filename: new URL('./contentWorker.js', import.meta.url).href,
   execArgv: process.execArgv,
   maxThreads: Number(process.env.PARSE_MAX_THREADS) || 2,
 })

--- a/server/fetcher/content.ts
+++ b/server/fetcher/content.ts
@@ -13,8 +13,10 @@ import type { ParseHtmlInput, ParseHtmlResult } from './contentWorker.js'
 // rather than with a runtime branch.
 const pool = new PiscinaPool({
   filename: new URL('./contentWorker.js', import.meta.url).href,
-  execArgv: process.execArgv,
+  execArgv: [...process.execArgv, '--max-old-space-size=256'],
   maxThreads: Number(process.env.PARSE_MAX_THREADS) || 2,
+  minThreads: 0,
+  idleTimeout: 30_000,
 })
 
 /** Per-task timeout for worker pool. */

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import jwt from '@fastify/jwt'
 import rateLimit from '@fastify/rate-limit'
 import multipart from '@fastify/multipart'
 import cron, { type ScheduledTask } from 'node-cron'
-import { runMigrations, getSetting, upsertSetting, getOrCreateJwtSecret, ensureClipFeed, recalculateScores, purgeExpiredArticles } from './db.js'
+import { runMigrations, getSetting, upsertSetting, getOrCreateJwtSecret, ensureClipFeed, recalculateScores, purgeExpiredArticles, shrinkMemory } from './db.js'
 import { logger } from './logger.js'
 import { findProjectRoot } from './paths.js'
 
@@ -189,6 +189,13 @@ cronTasks.push(cron.schedule(SCORE_RECALC_SCHEDULE, async () => {
   } catch (err) {
     log.error('[cron] Score recalculation error:', err)
   }
+}))
+
+// --- SQLite memory shrink ---
+// Periodic shrink_memory + wal_checkpoint to prevent libsql native heap accumulation.
+const SHRINK_MEM_SCHEDULE = process.env.SHRINK_MEM_SCHEDULE || '*/5 * * * *'
+cronTasks.push(cron.schedule(SHRINK_MEM_SCHEDULE, () => {
+  shrinkMemory()
 }))
 
 // --- Search index ---

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import multipart from '@fastify/multipart'
 import cron, { type ScheduledTask } from 'node-cron'
 import { runMigrations, getSetting, upsertSetting, getOrCreateJwtSecret, ensureClipFeed, recalculateScores, purgeExpiredArticles } from './db.js'
 import { logger } from './logger.js'
+import { findProjectRoot } from './paths.js'
 
 const log = logger
 import { getDb } from './db/connection.js'
@@ -27,7 +28,7 @@ if (process.env.AUTH_DISABLED === '1' && process.env.NODE_ENV !== 'development')
 }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const projectRoot = path.resolve(__dirname, '..')
+const projectRoot = findProjectRoot(__dirname)
 
 // --- Migrations ---
 runMigrations()

--- a/server/paths.ts
+++ b/server/paths.ts
@@ -33,3 +33,18 @@ export const DATA_DIR = resolveDataDir()
 export function dataPath(...segments: string[]): string {
   return path.join(DATA_DIR, ...segments)
 }
+
+/**
+ * Find the project root directory by walking up from __dirname until
+ * package.json is found. Works under both tsx (source) and compiled
+ * (dist/) environments where __dirname depth differs.
+ */
+export function findProjectRoot(dirname: string): string {
+  let dir = dirname
+  while (true) {
+    if (fs.existsSync(path.join(dir, 'package.json'))) return dir
+    const parent = path.dirname(dir)
+    if (parent === dir) return dir // hit filesystem root
+    dir = parent
+  }
+}

--- a/server/paths.ts
+++ b/server/paths.ts
@@ -37,7 +37,12 @@ export function dataPath(...segments: string[]): string {
 /**
  * Find the project root directory by walking up from __dirname until
  * package.json is found. Works under both tsx (source) and compiled
- * (dist/) environments where __dirname depth differs.
+ * (dist/ or dist-server/) environments where __dirname depth differs.
+ *
+ * Assumes a single-package layout (no monorepo workspaces) where the
+ * first package.json walking upward is the project root. Will produce
+ * incorrect results in a multi-package workspace with nested
+ * package.json files.
  */
 export function findProjectRoot(dirname: string): string {
   let dir = dirname

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -6,8 +6,10 @@ import { logger } from './logger.js'
 
 const log = logger.child('seed')
 
+import { findProjectRoot } from './paths.js'
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const projectRoot = path.resolve(__dirname, '..')
+const projectRoot = findProjectRoot(__dirname)
 
 /**
  * Resolve relative date strings (e.g. "-3d", "-2d23h") to ISO 8601.

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "../dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "..",
+    "types": ["node"]
+  },
+  "include": [
+    "../server/**/*.ts",
+    "../shared/**/*.ts"
+  ]
+}

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "outDir": "../dist",
+    "outDir": "../dist-server",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "rootDir": "..",


### PR DESCRIPTION
## Summary

Resolve recurring OOM crashes in the oksskolten-server container (2–5 hour crash cycle under 2 GB mem_limit) through a combination of build, runtime, and SQLite configuration changes.

**Root cause:** Uncontrolled heap growth inside **libsql (SQLite C binding)** — `PRAGMA soft_heap_limit` was 0 (unlimited). Secondary contributors included the tsx runtime (4 persistent esbuild child processes) and unbounded worker thread V8 isolate accumulation.

**Outcome after all fixes:** 13+ hours stable operation, RSS at 1.16 GiB / 3 GiB (38%), no upward trend.

---

## Changes

| Ref. | File | Change | Effect |
|------|------|--------|--------|
| C1 | `Dockerfile` | Add tsc build stage; CMD `node dist-server/server/index.js` | Eliminates tsx/esbuild memory overhead. RSS startup: ~900 MB → 333 MB |
| C1 | `server/tsconfig.build.json` (new) | `moduleResolution: NodeNext`, `outDir: ../dist-server` | Required for tsc compilation; placed outside fastifyStatic's `dist/` root to prevent information disclosure |
| C3 | `server/fetcher/content.ts` | Piscina: `idleTimeout: 30_000`, `minThreads: 0`, `execArgv: --max-old-space-size=256` | Worker V8 isolates recycled after 30s idle; PIDs 20→16 |
| C4 | `server/db/connection.ts` | `PRAGMA soft_heap_limit = 268435456` (256 MB) | Caps libsql internal C-level heap growth |
| C4+C5 | `server/db/connection.ts` | Exported `shrinkMemory()` — `wal_checkpoint(TRUNCATE)` + `shrink_memory` | Releases unused SQLite pages back to the OS |
| C5 | `server/index.ts` | 5-min in-process cron (`node-cron`) calling `shrinkMemory()` | Prevents baseline creep; 0.3% CPU duty cycle |
| — | `Dockerfile` | Remove `COPY server ./server` and `COPY shared ./shared` | Eliminates raw .ts sources from production image |
| — | `.gitignore` | Add `dist-server/` | Prevents accidental commits of compiled server output |

**Why both C4 and C5 are needed:** `soft_heap_limit` caps allocations but freed pages stay in the glibc arena (not returned to OS). `shrink_memory` explicitly releases stale pages to the OS — the two are complementary, not redundant.

---

## Key Evidence

### Before / After

| Metric | Before | After |
|--------|--------|-------|
| OOM crash interval | 2–5 hours | None in 13+ hours |
| RSS at startup | ~1,900 MB | ~333 MB |
| RSS stable range | 145 → 1,077 MB (creeping up) | 1,068–1,150 MB (flat 8+ hrs) |
| Anonymous pages | 91% (635 MB) | 73% (171 MB) baseline |
| PIDs | 20+ | 16 |

### Eliminated Hypotheses

All of these were instrumented with targeted probes and ruled out:
- V8 Old Space (main thread) — controlled by `--max-old-space-size=512`
- V8 Old Space (workers) — `idleTimeout` resets isolates, JSDOM confirmed GC-able
- undici HTTP connection pool — V8 external memory 5.8–9.5 MB stable
- glibc malloc arena fragmentation — `MALLOC_ARENA_MAX=2` showed zero effect
- rebuildSearchIndex bulk load — measured at only +15 MB RSS impact

---

## What's NOT Included (and why)

| Change | Reason |
|--------|--------|
| `mem_limit: 2g → 3g` | Environment-specific; operators should choose their own value |
| `MALLOC_ARENA_MAX=2` | Measured to have **zero effect** on growth rate |
| All probe/debug code | Debug instrumentation — not production code |
| `compose.yaml --max-old-space-size=512` | Deployment concern, not application code |

---

## Verification

- Full investigation report (14 days, 7 probes, 8 hypotheses eliminated) is available in the repo at `oksskolten-possible-issues.md`