### PR TITLE
refine(fonts): use curated stack for System Serif

### DIFF
--- a/src/data/articleFonts.ts
+++ b/src/data/articleFonts.ts
@@ -58,7 +58,7 @@ export const articleFonts: ArticleFont[] = [
   {
     value: 'system-serif',
     label: 'System Serif',
-    family: 'serif',
+    family: 'ui-serif, "New York", Charter, Cambria, "Times New Roman", serif',
     googleFontsUrl: null,
     category: 'serif',
   },


### PR DESCRIPTION
## Summary

- Follow-up to #65. System Serif used the bare `serif` generic; this gives the option more meaningful behaviour across platforms.
- Mirrors the System sans-serif entry's curated stack pattern (`ui-sans-serif` first, then explicit OS natives).
- Stack: `ui-serif, "New York", Charter, Cambria, "Times New Roman", serif`. Deliberately omits Georgia so this option stays distinct from the existing Georgia entry.

