### PR TITLE
test(fetcher): add Piscina worker spawn smoke test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,7 +72,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -101,7 +101,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: server-coverage
           path: coverage/server/coverage-summary.json
@@ -121,7 +121,7 @@ jobs:
 
       - name: Download base coverage
         if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@8a338493df3d275e4a7a63bcff3b8fe97e51a927 # v19
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           name: server-coverage
           path: coverage/server-base
@@ -141,7 +141,7 @@ jobs:
 
       - name: Coverage Report
         if: always() && github.event_name == 'pull_request'
-        uses: davelosert/vitest-coverage-report-action@2500dafcee7dd64f85ab689c0b83798a8359770e # v2.9.3
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
           name: Server Coverage
           json-summary-path: coverage/server/coverage-summary.json
@@ -163,7 +163,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: client-coverage
           path: coverage/client/coverage-summary.json
@@ -185,7 +185,7 @@ jobs:
 
       - name: Download base coverage
         if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@8a338493df3d275e4a7a63bcff3b8fe97e51a927 # v19
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           name: client-coverage
           path: coverage/client-base
@@ -205,11 +205,35 @@ jobs:
 
       - name: Coverage Report
         if: always() && github.event_name == 'pull_request'
-        uses: davelosert/vitest-coverage-report-action@2500dafcee7dd64f85ab689c0b83798a8359770e # v2.9.3
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
           name: Client Coverage
           json-summary-path: coverage/client/coverage-summary.json
           json-summary-compare-path: ${{ steps.check-base.outputs.exists == 'true' && 'coverage/client-base/coverage-summary.json' || '' }}
+
+  smoke-worker:
+    name: Worker Smoke Test
+    needs: detect-changes
+    if: needs.detect-changes.outputs.server == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Spawn Piscina worker and run one parse
+        run: npx tsx scripts/smoke-worker.ts
 
   lint-docs:
     name: Docs Lint
@@ -225,7 +249,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -251,14 +275,14 @@ jobs:
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [check, server-test, client-test, lint-docs]
+    needs: [check, server-test, client-test, smoke-worker, lint-docs]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
     steps:
       - name: Check results
         run: |
-          results=("${CHECK_RESULT}" "${SERVER_TEST_RESULT}" "${CLIENT_TEST_RESULT}" "${LINT_DOCS_RESULT}")
+          results=("${CHECK_RESULT}" "${SERVER_TEST_RESULT}" "${CLIENT_TEST_RESULT}" "${SMOKE_WORKER_RESULT}" "${LINT_DOCS_RESULT}")
           for r in "${results[@]}"; do
             if [[ "$r" != "success" && "$r" != "skipped" ]]; then
               echo "Job failed with result: $r"
@@ -269,4 +293,5 @@ jobs:
           CHECK_RESULT: ${{ needs.check.result }}
           SERVER_TEST_RESULT: ${{ needs.server-test.result }}
           CLIENT_TEST_RESULT: ${{ needs.client-test.result }}
+          SMOKE_WORKER_RESULT: ${{ needs.smoke-worker.result }}
           LINT_DOCS_RESULT: ${{ needs.lint-docs.result }}

--- a/scripts/smoke-worker.ts
+++ b/scripts/smoke-worker.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node --import tsx
+/**
+ * Smoke test: spawn the content fetcher's Piscina worker pool, run one
+ * end-to-end parse, and exit non-zero on failure.
+ *
+ * Vitest's worker environment does not propagate the tsx loader the way
+ * `tsx watch` does in real dev, so unit-level integration tests of the
+ * Piscina pool silently break on imports inside the worker. This script
+ * runs under plain `node --import tsx`, mirroring the production-relevant
+ * worker spawn path, and catches regressions in:
+ *
+ * - Piscina options that fail Node's Worker validation (e.g. V8 flags
+ *   like `--max-old-space-size` in execArgv).
+ * - Worker entry filename resolution (.ts vs .js, missing file).
+ * - Module graph errors inside contentWorker that prevent worker startup.
+ */
+import { createWorkerPool } from '../server/fetcher/content.js'
+
+const TEST_HTML = `
+<html>
+  <head><title>Smoke test</title></head>
+  <body>
+    <article>
+      <h1>Hello world</h1>
+      <p>This is a smoke test article with enough body text to satisfy
+      Readability's minimum extraction threshold. It contains several
+      sentences so the parser has something substantive to work with.</p>
+      <p>A second paragraph to push past the threshold comfortably.</p>
+    </article>
+  </body>
+</html>
+`
+
+async function main() {
+  const pool = createWorkerPool()
+  try {
+    const result = await pool.run({
+      html: TEST_HTML,
+      articleUrl: 'http://smoke-test.example.com/post',
+      cleanerConfig: undefined,
+    })
+    if (!result.fullText.includes('Hello world')) {
+      console.error('FAIL: worker returned unexpected output')
+      console.error('  fullText:', result.fullText.slice(0, 200))
+      process.exit(1)
+    }
+    console.log('OK: worker spawn and parse succeeded')
+  } finally {
+    await pool.destroy()
+  }
+}
+
+main().catch((err) => {
+  console.error('FAIL: worker pool error')
+  console.error(err)
+  process.exit(1)
+})

--- a/server/fetcher/content.ts
+++ b/server/fetcher/content.ts
@@ -25,19 +25,34 @@ const jsWorkerUrl = new URL('./contentWorker.js', import.meta.url)
 const tsWorkerUrl = new URL('./contentWorker.ts', import.meta.url)
 const workerUrl = fs.existsSync(fileURLToPath(jsWorkerUrl)) ? jsWorkerUrl : tsWorkerUrl
 
-const pool = new PiscinaPool({
-  filename: workerUrl.href,
-  execArgv: process.execArgv,
-  resourceLimits: {
-    maxOldGenerationSizeMb: 512,
-  },
-  maxThreads: Number(process.env.PARSE_MAX_THREADS) || 2,
-  // Keep at least one warm worker. minThreads: 0 forced a cold spawn for the
-  // first task in every sparse batch; the spawn-plus-parse latency could
-  // approach the per-task timeout under load.
-  minThreads: 1,
-  idleTimeout: 30_000,
-})
+/**
+ * Factory for the Piscina worker pool. Exported so integration tests can
+ * spawn an isolated pool without colliding with the production-side
+ * singleton in `getPool()`. Production code must always go through
+ * `getPool()`, not call this directly, to avoid duplicate pools.
+ */
+export function createWorkerPool(): PiscinaPool {
+  return new PiscinaPool({
+    filename: workerUrl.href,
+    execArgv: process.execArgv,
+    resourceLimits: {
+      maxOldGenerationSizeMb: 512,
+    },
+    maxThreads: Number(process.env.PARSE_MAX_THREADS) || 2,
+    // Keep at least one warm worker. minThreads: 0 forced a cold spawn for the
+    // first task in every sparse batch; the spawn-plus-parse latency could
+    // approach the per-task timeout under load.
+    minThreads: 1,
+    idleTimeout: 30_000,
+  })
+}
+
+let _pool: PiscinaPool | null = null
+
+function getPool(): PiscinaPool {
+  if (!_pool) _pool = createWorkerPool()
+  return _pool
+}
 
 /** Per-task timeout for worker pool. */
 const WORKER_TIMEOUT_MS = 45_000
@@ -53,7 +68,7 @@ async function runWithTimeout(input: ParseHtmlInput, timeoutMs: number): Promise
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(new Error('Worker timeout')), timeoutMs)
   try {
-    return await pool.run(input, { signal: controller.signal })
+    return await getPool().run(input, { signal: controller.signal })
   } finally {
     clearTimeout(timeoutId)
   }


### PR DESCRIPTION
## Summary

- #78 shipped Piscina settings that broke worker spawn in tsx dev (invalid `execArgv`, missing `.js` entry). Unit tests didn't catch it because `server/__tests__/setup.ts` mocks the entire `piscina` module.
- Add a standalone `scripts/smoke-worker.ts` that runs under plain `node --import tsx` and exercises the real worker pool end to end. Hooked into CI as a new `smoke-worker` job gated by server file changes; the CI gate now requires it to pass.
- Refactor `content.ts` minimally to support the smoke script: export `createWorkerPool()` and route production through a lazy `getPool()` singleton, so the script can build and tear down an isolated pool without colliding with the production-side instance.

## Why not a vitest integration test

Tried that first. Vitest's worker thread environment doesn't propagate the tsx loader the way `tsx watch` does in real dev, so the worker's own internal imports (`server/lib/cleaner/index.js` etc.) fail to resolve and the test breaks on environment differences rather than the bugs we want to catch. A standalone script under tsx mirrors real dev, so it catches both the spawn config and the worker module graph.

## Meta-verification

Re-injected the #78 `--max-old-space-size=512` execArgv bug locally:

```
FAIL: worker pool error
Error [ERR_WORKER_INVALID_EXEC_ARGV]: Initiated Worker with invalid execArgv flags: --max-old-space-size=512
    ...
    at createWorkerPool (.../server/fetcher/content.ts:35:10)
```

Stack trace points straight at the offending code. Reverted the bug, smoke went back to `OK`.

## Notes on the workflow diff

Running `pinact run -u` per the workflow rules updated a handful of unrelated action SHAs to their latest pinned versions (setup-node v6.3.0 -> v6.4.0, upload-artifact v7.0.0 -> v7.0.1, etc.). Kept those in the same commit since the rule requires running pinact after editing workflow files.
<!--
## Test plan
- [ ] Run `npx tsx scripts/smoke-worker.ts` locally; expect `OK`.
- [ ] After merge, verify CI runs the new `Worker Smoke Test` job on the next server-touching PR.