### PR TITLE
fix(search): skip startup rebuild when index is already populated

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,7 @@ import { authRoutes } from './authRoutes.js'
 import { passkeyRoutes } from './passkeyRoutes.js'
 import { oauthRoutes } from './oauthRoutes.js'
 import { fetchAllFeeds } from './fetcher.js'
-import { rebuildSearchIndex, isSearchReady, syncAllScoredArticlesToSearch } from './search/sync.js'
+import { ensureSearchIndex, rebuildSearchIndex, isSearchReady, syncAllScoredArticlesToSearch } from './search/sync.js'
 
 // --- Startup guards ---
 if (process.env.AUTH_DISABLED === '1' && process.env.NODE_ENV !== 'development') {
@@ -199,20 +199,24 @@ cronTasks.push(cron.schedule(SHRINK_MEM_SCHEDULE, () => {
 }))
 
 // --- Search index ---
-// Non-blocking: rebuild runs in background, search returns 503 until ready
-// Retry with backoff if initial rebuild fails (e.g. Meilisearch not yet ready)
+// Non-blocking: ensure the search index is ready in the background. Search
+// returns 503 until ready. `ensureSearchIndex` reuses an already-populated
+// index when one exists (the common case after a restart) and only triggers
+// a full rebuild when the index is missing or empty, so HMR restarts and
+// normal redeploys don't pile up rebuild tasks on the Meilisearch queue.
+// Retry with backoff if Meilisearch is not yet reachable on first attempt.
 void (async () => {
   const retries = [0, 5_000, 15_000, 30_000]
   for (const delay of retries) {
     if (delay) await new Promise((r) => setTimeout(r, delay))
     try {
-      await rebuildSearchIndex()
+      await ensureSearchIndex()
       return
     } catch (err) {
-      log.error(`[search] Index rebuild attempt failed (next retry in ${retries[retries.indexOf(delay) + 1] ?? 'none'}ms):`, err)
+      log.error(`[search] Index ensure attempt failed (next retry in ${retries[retries.indexOf(delay) + 1] ?? 'none'}ms):`, err)
     }
   }
-  log.error('[search] All initial rebuild attempts failed, will retry on next 6h cron')
+  log.error('[search] All initial ensure attempts failed, will retry on next 6h cron')
 })()
 
 cronTasks.push(cron.schedule('0 */6 * * *', async () => {

--- a/server/search/sync.test.ts
+++ b/server/search/sync.test.ts
@@ -203,6 +203,25 @@ describe('ensureSearchIndex', () => {
     expect(mockCreateIndex).toHaveBeenCalled()
   })
 
+  it('throws on settings-apply failure without triggering a full rebuild', async () => {
+    // Index is populated, so the skip path applies. If updateSettings hits
+    // a timeout (the same queue-pressure symptom that motivated this
+    // change), we must NOT cascade into the heavy rebuild because that
+    // would worsen the queue. Surface the error to the startup retry loop
+    // instead.
+    mockGetIndexes.mockResolvedValue({ results: [{ uid: 'articles' }] })
+    mockGetStats.mockResolvedValue({ numberOfDocuments: 42 })
+    mockWaitTask.mockRejectedValueOnce(new Error('MeiliSearchTaskTimeOutError: timeout'))
+
+    await expect(ensureSearchIndex()).rejects.toThrow()
+    expect(mockUpdateSettings).toHaveBeenCalledTimes(1)
+    // The full-rebuild operations must not have been reached.
+    expect(mockCreateIndex).not.toHaveBeenCalled()
+    expect(mockDeleteIndex).not.toHaveBeenCalled()
+    expect(mockSwapIndexes).not.toHaveBeenCalled()
+    expect(isSearchReady()).toBe(false)
+  })
+
   it('throws when the fallthrough rebuild fails so the startup retry loop can back off', async () => {
     // No indexes exist, so ensureSearchIndex must fall through to rebuild.
     // Make rebuildSearchIndex hit a hard failure that its internal catch

--- a/server/search/sync.test.ts
+++ b/server/search/sync.test.ts
@@ -2,20 +2,35 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setupTestDb } from '../__tests__/helpers/testDb.js'
 import { getDb } from '../db/connection.js'
 
-// Mock Meilisearch client
+// Mock Meilisearch client. Each method is exposed individually so individual
+// tests can override the return value (e.g. simulate "no indexes yet").
 const mockWaitTask = vi.fn().mockResolvedValue({})
 const mockUpdateDocuments = vi.fn().mockReturnValue({ waitTask: mockWaitTask })
+const mockAddDocuments = vi.fn().mockReturnValue({ waitTask: mockWaitTask })
+const mockUpdateSettings = vi.fn().mockReturnValue({ waitTask: mockWaitTask })
+const mockGetStats = vi.fn()
+const mockGetIndexes = vi.fn()
+const mockCreateIndex = vi.fn().mockReturnValue({ waitTask: mockWaitTask })
+const mockDeleteIndex = vi.fn().mockReturnValue({ waitTask: mockWaitTask })
+const mockSwapIndexes = vi.fn().mockReturnValue({ waitTask: mockWaitTask })
 vi.mock('./client.js', () => ({
   getSearchClient: () => ({
+    getIndexes: mockGetIndexes,
     index: () => ({
       updateDocuments: mockUpdateDocuments,
+      addDocuments: mockAddDocuments,
+      updateSettings: mockUpdateSettings,
+      getStats: mockGetStats,
     }),
+    createIndex: mockCreateIndex,
+    deleteIndex: mockDeleteIndex,
+    swapIndexes: mockSwapIndexes,
   }),
   ARTICLES_INDEX: 'articles',
   ARTICLES_STAGING_INDEX: 'articles_staging',
 }))
 
-import { syncAllScoredArticlesToSearch, _setRebuilding } from './sync.js'
+import { ensureSearchIndex, isSearchReady, syncAllScoredArticlesToSearch, _setRebuilding } from './sync.js'
 
 function seedFeed(): number {
   return getDb().prepare(
@@ -120,5 +135,63 @@ describe('syncAllScoredArticlesToSearch', () => {
 
     const docs = mockUpdateDocuments.mock.calls[0][0] as Record<string, unknown>[]
     expect(Object.keys(docs[0]).sort()).toEqual(['id', 'score'])
+  })
+})
+
+describe('ensureSearchIndex', () => {
+  beforeEach(() => {
+    setupTestDb()
+    mockGetIndexes.mockReset()
+    mockGetStats.mockReset()
+    mockCreateIndex.mockClear()
+    mockDeleteIndex.mockClear()
+    mockAddDocuments.mockClear()
+    mockSwapIndexes.mockClear()
+    mockUpdateSettings.mockClear()
+    mockUpdateDocuments.mockClear()
+    mockWaitTask.mockClear()
+    _setRebuilding(false)
+  })
+
+  it('skips rebuild when the articles index already has documents', async () => {
+    mockGetIndexes.mockResolvedValue({ results: [{ uid: 'articles' }] })
+    mockGetStats.mockResolvedValue({ numberOfDocuments: 42 })
+
+    await ensureSearchIndex()
+
+    expect(isSearchReady()).toBe(true)
+    // Skipping means we never touch any of the heavy rebuild operations.
+    expect(mockCreateIndex).not.toHaveBeenCalled()
+    expect(mockDeleteIndex).not.toHaveBeenCalled()
+    expect(mockAddDocuments).not.toHaveBeenCalled()
+  })
+
+  it('falls through to rebuild when the articles index is missing', async () => {
+    mockGetIndexes.mockResolvedValue({ results: [] })
+
+    await ensureSearchIndex()
+
+    expect(mockCreateIndex).toHaveBeenCalled()
+  })
+
+  it('falls through to rebuild when the articles index is empty', async () => {
+    mockGetIndexes.mockResolvedValue({ results: [{ uid: 'articles' }] })
+    mockGetStats.mockResolvedValue({ numberOfDocuments: 0 })
+
+    await ensureSearchIndex()
+
+    expect(mockCreateIndex).toHaveBeenCalled()
+  })
+
+  it('falls through to rebuild when the existence check throws', async () => {
+    // Meilisearch transient failure on the first existence check; the
+    // function should still try a rebuild rather than declaring search
+    // ready against an unknown state.
+    mockGetIndexes.mockRejectedValueOnce(new Error('connection refused'))
+    mockGetIndexes.mockResolvedValue({ results: [] })
+
+    await ensureSearchIndex()
+
+    expect(mockCreateIndex).toHaveBeenCalled()
   })
 })

--- a/server/search/sync.test.ts
+++ b/server/search/sync.test.ts
@@ -30,7 +30,7 @@ vi.mock('./client.js', () => ({
   ARTICLES_STAGING_INDEX: 'articles_staging',
 }))
 
-import { ensureSearchIndex, isSearchReady, syncAllScoredArticlesToSearch, _setRebuilding } from './sync.js'
+import { ensureSearchIndex, isSearchReady, syncAllScoredArticlesToSearch, _setRebuilding, _setSearchReady } from './sync.js'
 
 function seedFeed(): number {
   return getDb().prepare(
@@ -151,19 +151,27 @@ describe('ensureSearchIndex', () => {
     mockUpdateDocuments.mockClear()
     mockWaitTask.mockClear()
     _setRebuilding(false)
+    _setSearchReady(false)
   })
 
-  it('skips rebuild when the articles index already has documents', async () => {
+  it('skips rebuild when the articles index already has documents and reapplies settings idempotently', async () => {
     mockGetIndexes.mockResolvedValue({ results: [{ uid: 'articles' }] })
     mockGetStats.mockResolvedValue({ numberOfDocuments: 42 })
 
     await ensureSearchIndex()
 
     expect(isSearchReady()).toBe(true)
-    // Skipping means we never touch any of the heavy rebuild operations.
+    // Skipping means we never touch the heavy create / swap operations.
     expect(mockCreateIndex).not.toHaveBeenCalled()
     expect(mockDeleteIndex).not.toHaveBeenCalled()
     expect(mockAddDocuments).not.toHaveBeenCalled()
+    // Settings must still be reapplied so a redeploy that changed the
+    // schema (new filterable attribute, etc.) picks it up without waiting
+    // for the 6h cron rebuild.
+    expect(mockUpdateSettings).toHaveBeenCalledTimes(1)
+    const appliedSettings = mockUpdateSettings.mock.calls[0][0] as Record<string, unknown>
+    expect(appliedSettings).toHaveProperty('filterableAttributes')
+    expect(appliedSettings).toHaveProperty('searchableAttributes')
   })
 
   it('falls through to rebuild when the articles index is missing', async () => {
@@ -193,5 +201,17 @@ describe('ensureSearchIndex', () => {
     await ensureSearchIndex()
 
     expect(mockCreateIndex).toHaveBeenCalled()
+  })
+
+  it('throws when the fallthrough rebuild fails so the startup retry loop can back off', async () => {
+    // No indexes exist, so ensureSearchIndex must fall through to rebuild.
+    // Make rebuildSearchIndex hit a hard failure that its internal catch
+    // will swallow without setting searchReady. ensureSearchIndex must
+    // surface that as a thrown error to its caller.
+    mockGetIndexes.mockResolvedValueOnce({ results: [] }) // ensure check: no articles
+    mockGetIndexes.mockRejectedValueOnce(new Error('meili down')) // rebuild's own check
+
+    await expect(ensureSearchIndex()).rejects.toThrow(/rebuild/i)
+    expect(isSearchReady()).toBe(false)
   })
 })

--- a/server/search/sync.ts
+++ b/server/search/sync.ts
@@ -164,6 +164,10 @@ export async function rebuildSearchIndex(): Promise<void> {
  * full refresh still happens periodically.
  */
 export async function ensureSearchIndex(): Promise<void> {
+  // Step 1: existence and population check. Failures here usually mean
+  // Meilisearch is unreachable, so we want to fall through to the rebuild
+  // path so the startup retry loop can confirm whether Meili is back.
+  let populatedDocCount = 0
   try {
     const client = getSearchClient()
     const { results: existingIndexes } = await client.getIndexes()
@@ -171,19 +175,30 @@ export async function ensureSearchIndex(): Promise<void> {
     if (articles) {
       const stats = await client.index(ARTICLES_INDEX).getStats()
       if (stats.numberOfDocuments > 0) {
-        // Apply current INDEX_SETTINGS idempotently so a redeploy that
-        // changed filterableAttributes / searchableAttributes / etc. still
-        // picks up the new schema without paying for a full rebuild.
-        // Meilisearch treats matching settings as a no-op.
-        await client.index(ARTICLES_INDEX).updateSettings(INDEX_SETTINGS).waitTask({ timeout: MEILI_TASK_TIMEOUT_MS })
-        searchReady = true
-        log.info(`Search index already populated (${stats.numberOfDocuments} docs); skipping startup rebuild`)
-        return
+        populatedDocCount = stats.numberOfDocuments
       }
     }
   } catch (err) {
-    log.warn('ensureSearchIndex check failed; falling through to rebuild:', err)
+    log.warn('ensureSearchIndex existence check failed; falling through to rebuild:', err)
   }
+
+  if (populatedDocCount > 0) {
+    // Step 2: schema sync. Apply current INDEX_SETTINGS idempotently so a
+    // redeploy that changed filterableAttributes / searchableAttributes
+    // picks up the new schema without paying for a full rebuild.
+    // Deliberately do NOT fall back to rebuildSearchIndex on failure here:
+    // the only way this fails is Meilisearch queue pressure or a transient
+    // error, and triggering a full rebuild (delete + create + swap +
+    // batches) under that condition is exactly what produced the original
+    // "Index articles_staging already exists" pile-up. Surface the error
+    // to the startup retry loop instead so it backs off cleanly.
+    const client = getSearchClient()
+    await client.index(ARTICLES_INDEX).updateSettings(INDEX_SETTINGS).waitTask({ timeout: MEILI_TASK_TIMEOUT_MS })
+    searchReady = true
+    log.info(`Search index already populated (${populatedDocCount} docs); skipping startup rebuild`)
+    return
+  }
+
   await rebuildSearchIndex()
   if (!searchReady) {
     // rebuildSearchIndex swallows its own errors and just leaves

--- a/server/search/sync.ts
+++ b/server/search/sync.ts
@@ -143,6 +143,40 @@ export async function rebuildSearchIndex(): Promise<void> {
   }
 }
 
+/**
+ * Idempotent startup hook for search. Inspects the Meilisearch state and
+ * only triggers a full `rebuildSearchIndex()` if the articles index is
+ * missing or empty. When the index is already populated — the common case
+ * after a tsx-watch HMR restart or a normal prod redeploy — flip
+ * searchReady on and return immediately.
+ *
+ * This avoids the race that happens when each restart fires a fresh
+ * rebuild while the previous process's index-management tasks are still
+ * in the Meilisearch queue (the symptom is "Index `articles_staging`
+ * already exists" failures and waitTask timeouts piling up).
+ *
+ * The 6-hour cron continues to call `rebuildSearchIndex()` directly so a
+ * full refresh still happens periodically.
+ */
+export async function ensureSearchIndex(): Promise<void> {
+  try {
+    const client = getSearchClient()
+    const { results: existingIndexes } = await client.getIndexes()
+    const articles = existingIndexes.find((idx: { uid: string }) => idx.uid === ARTICLES_INDEX)
+    if (articles) {
+      const stats = await client.index(ARTICLES_INDEX).getStats()
+      if (stats.numberOfDocuments > 0) {
+        searchReady = true
+        log.info(`Search index already populated (${stats.numberOfDocuments} docs); skipping startup rebuild`)
+        return
+      }
+    }
+  } catch (err) {
+    log.warn('ensureSearchIndex check failed; falling through to rebuild:', err)
+  }
+  await rebuildSearchIndex()
+}
+
 // --- Fire-and-forget sync helpers ---
 
 export function syncArticleToSearch(doc: MeiliArticleDoc): void {

--- a/server/search/sync.ts
+++ b/server/search/sync.ts
@@ -19,6 +19,11 @@ export function _setRebuilding(value: boolean): void {
   rebuilding = value
 }
 
+/** @internal Test-only helper to reset the searchReady flag between cases */
+export function _setSearchReady(value: boolean): void {
+  searchReady = value
+}
+
 // --- Change log for rebuild consistency ---
 
 type ChangeEntry =
@@ -166,6 +171,11 @@ export async function ensureSearchIndex(): Promise<void> {
     if (articles) {
       const stats = await client.index(ARTICLES_INDEX).getStats()
       if (stats.numberOfDocuments > 0) {
+        // Apply current INDEX_SETTINGS idempotently so a redeploy that
+        // changed filterableAttributes / searchableAttributes / etc. still
+        // picks up the new schema without paying for a full rebuild.
+        // Meilisearch treats matching settings as a no-op.
+        await client.index(ARTICLES_INDEX).updateSettings(INDEX_SETTINGS).waitTask({ timeout: MEILI_TASK_TIMEOUT_MS })
         searchReady = true
         log.info(`Search index already populated (${stats.numberOfDocuments} docs); skipping startup rebuild`)
         return
@@ -175,6 +185,13 @@ export async function ensureSearchIndex(): Promise<void> {
     log.warn('ensureSearchIndex check failed; falling through to rebuild:', err)
   }
   await rebuildSearchIndex()
+  if (!searchReady) {
+    // rebuildSearchIndex swallows its own errors and just leaves
+    // searchReady at its prior value. Surface that as a thrown error so
+    // the startup retry loop in server/index.ts can back off and try
+    // again instead of declaring success against an unbuilt index.
+    throw new Error('Search index rebuild did not complete')
+  }
 }
 
 // --- Fire-and-forget sync helpers ---


### PR DESCRIPTION
## Summary

Every server start fired a full `rebuildSearchIndex` regardless of the current Meilisearch state. In dev each tsx-watch HMR restart queued a fresh rebuild while the previous process's index management tasks were still in flight, surfacing as `Index articles_staging already exists` failures and `MeiliSearchTaskTimeOutError` from `waitTask` piling up. The same shape happens on every prod redeploy, just less often.

Add `ensureSearchIndex`: it asks Meilisearch whether the articles index exists and has documents, reapplies the current `INDEX_SETTINGS` idempotently, marks `searchReady`, and returns. Only empty or missing indexes fall through to the full rebuild. The 6-hour cron continues to call `rebuildSearchIndex` directly for a true periodic refresh.

`server/index.ts` wires the startup task to `ensureSearchIndex` and keeps the cron pointing at `rebuildSearchIndex`.

## Why reapply settings on skip

A redeploy that changes `filterableAttributes` / `searchableAttributes` / etc. would otherwise leave the index running with stale schema until the next 6-hour rebuild, breaking `/api/articles/search` filter queries in the meantime. Meilisearch treats matching settings as a no-op so reapplying every startup is cheap.

## Why we throw on rebuild fallthrough failure

`rebuildSearchIndex` swallows its own errors internally. Without surfacing them, the startup retry loop in `server/index.ts` would treat a Meilisearch outage as "success" and stop retrying. After the fallthrough rebuild we check `searchReady` and throw when it is still false so the existing backoff loop runs.

## Out of scope

Cross-process race on the empty-index path (first deploy ever, or wiping the Meilisearch volume during dev). With `articles` already populated the skip path avoids the race entirely. When the index is missing, two concurrent processes can still both attempt to create `articles_staging`. Resolving that needs Meilisearch-side coordination (unique staging names per attempt, a task-based lock, or skipping startup during HMR explicitly). Left for a follow-up since the symptom only fires on a brand-new setup.

## Effect

- Dev HMR restart against an existing index: two Meili calls (`getIndexes` + `getStats`) plus an idempotent `updateSettings`, no rebuild tasks queued.
- Prod redeploy: same.
- First-ever deploy or empty index: still triggers the full rebuild.
- Schema change in a deploy: picked up via the idempotent settings reapply.