### PR TITLE
feat: allow http:// URLs for feeds and articles

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
     <title>Oksskolten</title>
     <meta name="description" content="AI-native RSS reader with full-text extraction, summarization, translation, and interactive chat." />

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -279,22 +279,55 @@ describe('GET /api/articles/by-url', () => {
     })
     expect(res.statusCode).toBe(404)
   })
+
+  it('handles protocol fallback (https -> http)', async () => {
+    const feed = seedFeed()
+    seedArticle(feed.id, { url: 'http://example.com/http-only' })
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/articles/by-url?url=https://example.com/http-only',
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().url).toBe('http://example.com/http-only')
+  })
+
+  it('handles protocol fallback (http -> https)', async () => {
+    const feed = seedFeed()
+    seedArticle(feed.id, { url: 'https://example.com/https-only' })
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/articles/by-url?url=http://example.com/https-only',
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().url).toBe('https://example.com/https-only')
+  })
 })
 
 describe('POST /api/articles/check-urls', () => {
-  it('returns existing URLs', async () => {
+  it('returns existing URLs including protocol-agnostic matches', async () => {
     const feed = seedFeed()
-    seedArticle(feed.id, { url: 'https://example.com/exists' })
+    seedArticle(feed.id, { url: 'http://example.com/check-1' })
+    seedArticle(feed.id, { url: 'https://example.com/check-2' })
 
     const res = await app.inject({
       method: 'POST',
       url: '/api/articles/check-urls',
       headers: json,
-      payload: { urls: ['https://example.com/exists', 'https://example.com/not'] },
+      payload: {
+        urls: [
+          'https://example.com/check-1', // input https, DB has http
+          'http://example.com/check-2',  // input http, DB has https
+          'https://example.com/check-3', // not in DB
+        ],
+      },
     })
     expect(res.statusCode).toBe(200)
-    expect(res.json().existing).toContain('https://example.com/exists')
-    expect(res.json().existing).not.toContain('https://example.com/not')
+    const { existing } = res.json()
+    expect(existing).toContain('https://example.com/check-1')
+    expect(existing).toContain('http://example.com/check-2')
+    expect(existing).not.toContain('https://example.com/check-3')
   })
 
   it('returns 400 for empty array', async () => {

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -246,6 +246,24 @@ describe('Articles', () => {
     expect(article!.url).toBe('https://example.com/%E8%A8%98%E4%BA%8B')
   })
 
+  it('getArticleByUrl handles protocol fallback (https -> http)', () => {
+    const feed = seedFeed()
+    seedArticle(feed.id, { url: 'http://example.com/http-only' })
+
+    const article = getArticleByUrl('https://example.com/http-only')
+    expect(article).toBeDefined()
+    expect(article!.url).toBe('http://example.com/http-only')
+  })
+
+  it('getArticleByUrl handles protocol fallback (http -> https)', () => {
+    const feed = seedFeed()
+    seedArticle(feed.id, { url: 'https://example.com/https-article' })
+
+    const article = getArticleByUrl('http://example.com/https-article')
+    expect(article).toBeDefined()
+    expect(article!.url).toBe('https://example.com/https-article')
+  })
+
 
   describe('getArticles filtering', () => {
     it('filters by feedId', () => {

--- a/server/db/articles.ts
+++ b/server/db/articles.ts
@@ -495,7 +495,11 @@ export function getExistingArticleUrls(urls: string[]): Set<string> {
 
   // Query both protocol variants so a feed item that arrives as https://
   // is treated as duplicate when we already stored it as http://, and
-  // vice versa.
+  // vice versa. This is an intentional design trade-off: sites that serve
+  // genuinely different content at http:// vs https:// (extremely rare for
+  // RSS feeds) would lose the http version. The alternative — strict
+  // per-protocol dedup — causes duplicate articles when the same blog is
+  // referenced under both protocols in different feeds.
   const expanded = new Set<string>()
   for (const u of normalized) {
     expanded.add(u)

--- a/server/db/articles.ts
+++ b/server/db/articles.ts
@@ -206,7 +206,9 @@ export function getArticles(opts: {
 }
 
 export function getArticleByUrl(url: string): ArticleDetail | undefined {
-  return getDb().prepare(`
+  const db = getDb()
+  const normalized = normalizeUrl(url)
+  const stmt = db.prepare(`
     SELECT a.id, a.feed_id, f.name AS feed_name, f.type AS feed_type,
            a.title, a.url, a.published_at, a.lang, a.summary, a.excerpt, a.og_image,
            a.full_text, a.full_text_translated, a.translated_lang, a.seen_at, a.read_at, a.bookmarked_at, a.liked_at,
@@ -215,7 +217,25 @@ export function getArticleByUrl(url: string): ArticleDetail | undefined {
     FROM active_articles a
     JOIN feeds f ON a.feed_id = f.id
     WHERE a.url = ?
-  `).get(normalizeUrl(url)) as ArticleDetail | undefined
+  `)
+
+  const article = stmt.get(normalized) as ArticleDetail | undefined
+  if (article) return article
+
+  // Protocol fallback: handle articles stored under one protocol when the
+  // request arrives with the other. This covers the transition period where
+  // some articles were saved before http:// feed registration was allowed.
+  let fallbackUrl: string | null = null
+  if (normalized.startsWith('https://')) {
+    fallbackUrl = 'http://' + normalized.slice(8)
+  } else if (normalized.startsWith('http://')) {
+    fallbackUrl = 'https://' + normalized.slice(7)
+  }
+  if (fallbackUrl) {
+    return stmt.get(fallbackUrl) as ArticleDetail | undefined
+  }
+
+  return undefined
 }
 
 export function getArticleById(id: number): ArticleDetail | undefined {
@@ -472,11 +492,33 @@ export function countStaleArticlesByFeed(feedId: number, minLength: number): num
 export function getExistingArticleUrls(urls: string[]): Set<string> {
   if (urls.length === 0) return new Set()
   const normalized = urls.map(normalizeUrl)
-  const placeholders = normalized.map(() => '?').join(',')
+
+  // Query both protocol variants so a feed item that arrives as https://
+  // is treated as duplicate when we already stored it as http://, and
+  // vice versa.
+  const expanded = new Set<string>()
+  for (const u of normalized) {
+    expanded.add(u)
+    if (u.startsWith('https://')) {
+      expanded.add('http://' + u.slice(8))
+    } else if (u.startsWith('http://')) {
+      expanded.add('https://' + u.slice(7))
+    }
+  }
+  const expandedList = [...expanded]
+  const placeholders = expandedList.map(() => '?').join(',')
   const rows = getDb().prepare(
     `SELECT url FROM articles WHERE url IN (${placeholders})`,
-  ).all(...normalized) as { url: string }[]
-  return new Set(rows.map(r => r.url))
+  ).all(...expandedList) as { url: string }[]
+
+  const dbUrls = new Set(rows.map(r => r.url))
+  const existing = new Set<string>()
+  for (const u of normalized) {
+    if (dbUrls.has(u)) { existing.add(u); continue }
+    if (u.startsWith('https://') && dbUrls.has('http://' + u.slice(8))) existing.add(u)
+    else if (u.startsWith('http://') && dbUrls.has('https://' + u.slice(7))) existing.add(u)
+  }
+  return existing
 }
 
 // Backoff deadline: datetime when the article becomes eligible for retry again.

--- a/server/index.ts
+++ b/server/index.ts
@@ -111,7 +111,7 @@ app.addHook('onRequest', (_req, reply, done) => {
   reply.header('X-Frame-Options', 'DENY')
   reply.header('X-Content-Type-Options', 'nosniff')
   reply.header('Referrer-Policy', 'strict-origin-when-cross-origin')
-  reply.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https: http: data:; connect-src 'self'; frame-ancestors 'none'")
+  reply.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https: data:; connect-src 'self'; frame-ancestors 'none'")
   done()
 })
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -110,7 +110,8 @@ app.addHook('onResponse', (req, reply, done) => {
 app.addHook('onRequest', (_req, reply, done) => {
   reply.header('X-Frame-Options', 'DENY')
   reply.header('X-Content-Type-Options', 'nosniff')
-  reply.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https: data:; connect-src 'self'; frame-ancestors 'none'")
+  reply.header('Referrer-Policy', 'strict-origin-when-cross-origin')
+  reply.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https: http: data:; connect-src 'self'; frame-ancestors 'none'")
   done()
 })
 

--- a/server/routes/articles.ts
+++ b/server/routes/articles.ts
@@ -88,14 +88,14 @@ const CheckUrlsBody = z.object({
   urls: z.array(z.string()).min(1, 'urls must be a non-empty array').max(MAX_CHECK_URLS, `Maximum ${MAX_CHECK_URLS} urls per request`),
 })
 
-const httpsUrl = z
+const httpOrHttpsUrl = z
   .string({ error: 'url is required' })
   .min(1, 'url is required')
   .url('must be a valid URL')
-  .refine((u) => u.startsWith('https://'), { message: 'Only https:// URLs are allowed' })
+  .refine((u) => u.startsWith('https://') || u.startsWith('http://'), { message: 'Only http:// or https:// URLs are allowed' })
 
 const FromUrlBody = z.object({
-  url: httpsUrl,
+  url: httpOrHttpsUrl,
   title: z.string().optional(),
   force: z.boolean().optional(),
 })

--- a/server/routes/clip-articles.test.ts
+++ b/server/routes/clip-articles.test.ts
@@ -107,6 +107,20 @@ describe('POST /api/articles/from-url', () => {
     expect(mockFetchArticleContent).toHaveBeenCalledWith('https://blog.example.com/post-1')
   })
 
+  it('201: creates article with http:// URL', async () => {
+    ensureClipFeed()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/articles/from-url',
+      headers: json,
+      payload: { url: 'http://blog.example.com/post-http' },
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(mockFetchArticleContent).toHaveBeenCalledWith('http://blog.example.com/post-http')
+  })
+
   it('201: uses provided title over fetched title', async () => {
     ensureClipFeed()
 

--- a/server/routes/feeds.test.ts
+++ b/server/routes/feeds.test.ts
@@ -266,7 +266,7 @@ describe('POST /api/feeds — RSS discovery pipeline', () => {
     expect(hasErrorOrDone).toBe(true)
   })
 
-  it('rejects http:// URLs', async () => {
+  it('accepts http:// URLs', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/feeds',
@@ -274,7 +274,19 @@ describe('POST /api/feeds — RSS discovery pipeline', () => {
       payload: { url: 'http://example.com/feed' },
     })
 
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('rejects ftp:// URLs', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/feeds',
+      headers: json,
+      payload: { url: 'ftp://example.com/feed' },
+    })
+
     expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatch(/Only http:\/\/ or https:\/\/ URLs are allowed/i)
   })
 
   it('rejects invalid URLs', async () => {

--- a/server/routes/feeds.ts
+++ b/server/routes/feeds.ts
@@ -27,23 +27,23 @@ import { queryRssBridge, inferCssSelectorBridge } from '../rss-bridge.js'
 import { parseOpml, generateOpml } from '../opml.js'
 import { NumericIdParams, parseOrBadRequest } from '../lib/validation.js'
 
-const httpsUrl = z
+const httpOrHttpsUrl = z
   .string({ error: 'url is required' })
   .min(1, 'url is required')
   .url('must be a valid URL')
-  .refine((u) => u.startsWith('https://'), { message: 'Only https:// URLs are allowed' })
+  .refine((u) => u.startsWith('https://') || u.startsWith('http://'), { message: 'Only http:// or https:// URLs are allowed' })
 
 const DiscoverTitleQuery = z.object({
-  url: httpsUrl,
+  url: httpOrHttpsUrl,
 })
 
 const CreateFeedBody = z
   .object({
-    url: httpsUrl,
+    url: httpOrHttpsUrl,
     name: z.string().optional(),
     category_id: z.number().nullable().optional(),
     // Phase 2: user chose "whole site" — use this exact RSS URL
-    discovered_rss_url: httpsUrl.optional(),
+    discovered_rss_url: httpOrHttpsUrl.optional(),
     discovered_rss_title: z.string().optional(),
     // Phase 2: user chose "this page only" — skip to LLM inference
     force_page_selector: z.boolean().optional(),

--- a/server/routes/settings.test.ts
+++ b/server/routes/settings.test.ts
@@ -690,6 +690,9 @@ describe('PATCH /api/settings/preferences — retention validation', () => {
 
 describe('vLLM endpoints', () => {
   it('GET /api/settings/vllm/status returns connection failed when unreachable', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('fetch failed'))
+    vi.stubGlobal('fetch', mockFetch)
+
     const res = await app.inject({
       method: 'GET',
       url: '/api/settings/vllm/status',
@@ -697,7 +700,7 @@ describe('vLLM endpoints', () => {
     expect(res.statusCode).toBe(200)
     const body = res.json()
     expect(body.ok).toBe(false)
-    expect(body.error).toBeDefined()
+    expect(body.error).toBe('fetch failed')
   })
 
   it('PATCH /api/settings/preferences updates vllm.base_url', async () => {

--- a/shared/url.ts
+++ b/shared/url.ts
@@ -5,6 +5,10 @@
  * query parameters by the browser / React Router.
  */
 export function articleUrlToPath(url: string): string {
+  const isHttp = url.startsWith('http://')
   const raw = url.replace(/^https?:\/\//, '')
-  return '/' + raw.replace(/\?/g, '%3F').replace(/&/g, '%26').replace(/=/g, '%3D').replace(/#/g, '%23')
+  const path = raw.replace(/\?/g, '%3F').replace(/&/g, '%26').replace(/=/g, '%3D').replace(/#/g, '%23')
+  // http:// articles get a /http/ prefix so the detail page can reconstruct
+  // the original protocol without hardcoding https://.
+  return isHttp ? '/http/' + path : '/' + path
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -221,12 +221,17 @@ function ArticleDetailPage() {
 
   if (!splat) return null
 
+  // Reconstruct the article URL, preserving the original protocol.
+  // http:// articles are routed as /http/<host>/<path> so this page can
+  // reconstruct the exact stored URL without hardcoding https://.
+  const rawSplat = splat.endsWith('.md') ? splat.slice(0, -3) : splat
+  const articleUrl = rawSplat.startsWith('http/')
+    ? `http://${decodeURIComponent(rawSplat.slice(5))}`
+    : `https://${decodeURIComponent(rawSplat)}`
+
   if (splat.endsWith('.md')) {
-    const articleUrl = `https://${decodeURIComponent(splat.slice(0, -3))}`
     return <ArticleRawPage articleUrl={articleUrl} />
   }
-
-  const articleUrl = `https://${decodeURIComponent(splat)}`
 
   return (
     <>

--- a/src/components/article/article-detail.tsx
+++ b/src/components/article/article-detail.tsx
@@ -108,7 +108,7 @@ export function ArticleDetail({ articleUrl, enableZapNavigation = false }: Artic
 
   const { rewrittenHtml: displayContent } = useRewriteInternalLinks(
     content,
-    articleUrl,
+    article?.url || articleUrl,
     internalLinks === 'on',
   )
 

--- a/src/components/feed/article-step.tsx
+++ b/src/components/feed/article-step.tsx
@@ -38,8 +38,8 @@ export function ArticleStep({ onClose, onCreated, onArticleCreated }: ArticleSte
         setConflict({ article: err.data.article as { id: number; url: string; feed_id: number; feed_name: string } })
       } else if (err instanceof ApiError && err.status === 409) {
         setError({ message: t('modal.clipAlreadyExists'), isInfo: true })
-      } else if (err instanceof ApiError && err.message.includes('https://')) {
-        setError({ message: t('modal.errorHttpsOnly') })
+      } else if (err instanceof ApiError && err.message.includes('http:// or https://')) {
+        setError({ message: t('modal.errorHttpOrHttpsOnly') })
       } else {
         setError({ message: err instanceof Error ? err.message : t('modal.genericError') })
       }

--- a/src/components/feed/feed-step.tsx
+++ b/src/components/feed/feed-step.tsx
@@ -16,7 +16,7 @@ function localizeServerError(raw: string, t: TranslateFn): string {
   if (raw.includes('RSS could not be detected')) return t('modal.errorRssNotDetected')
   if (raw.includes('Could not extract content')) return t('modal.errorPageExtract')
   if (raw.includes('already exists')) return t('modal.errorAlreadyExists')
-  if (raw.includes('https://')) return t('modal.errorHttpsOnly')
+  if (raw.includes('http:// or https://')) return t('modal.errorHttpOrHttpsOnly')
   return raw || t('modal.genericError')
 }
 

--- a/src/hooks/use-rewrite-internal-links.ts
+++ b/src/hooks/use-rewrite-internal-links.ts
@@ -67,10 +67,8 @@ export function useRewriteInternalLinks(
 
     setRewriting(true)
 
-    // Send canonical URLs; DB stores https:// URLs
-    const urls = [...candidates.keys()].map((u) =>
-      u.replace(/^http:\/\//, 'https://'),
-    )
+    // Send canonical URLs as-is; the backend now handles both http:// and https://
+    const urls = [...candidates.keys()]
 
     apiPost('/api/articles/check-urls', { urls })
       .then((data: { existing: string[] }) => {
@@ -78,9 +76,8 @@ export function useRewriteInternalLinks(
 
         const existingSet = new Set(data.existing)
         for (const [canonical, elements] of candidates) {
-          const httpsCanonical = canonical.replace(/^http:\/\//, 'https://')
-          if (existingSet.has(httpsCanonical)) {
-            const internalPath = articleUrlToPath(httpsCanonical)
+          if (existingSet.has(canonical)) {
+            const internalPath = articleUrlToPath(canonical)
             for (const el of elements) {
               el.setAttribute('href', internalPath)
               el.setAttribute('data-internal-link', 'true')

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -169,7 +169,7 @@ const dict = {
   'modal.add': { ja: '追加', en: 'Add' },
   'modal.errorRssNotDetected': { ja: 'このURLからRSSフィードを検出できませんでした', en: 'RSS could not be detected for this URL' },
   'modal.errorAlreadyExists': { ja: 'このフィードは既に登録されています', en: 'This feed already exists' },
-  'modal.errorHttpsOnly': { ja: 'https:// で始まるURLのみ対応しています', en: 'Only https:// URLs are allowed' },
+  'modal.errorHttpOrHttpsOnly': { ja: 'http:// または https:// で始まるURLのみ対応しています', en: 'Only http:// or https:// URLs are allowed' },
   'modal.genericError': { ja: 'エラーが発生しました', en: 'An error occurred' },
   'modal.step.rssDiscovery': { ja: 'RSS 検出', en: 'RSS discovery' },
   'modal.step.flaresolverr': { ja: 'JSレンダリング', en: 'JS rendering' },


### PR DESCRIPTION
Closes #63. Closes #62 (supersedes the rewrite submitted there).

## Summary

Legacy blogs (e.g. livedoor blog, and many Japanese blog services) serve RSS over plain http:// and could not be registered or browsed because the validator enforced https://. This PR relaxes that constraint end-to-end while keeping the security properties intact.

## What changed

Validation: `httpsUrl` renamed to `httpOrHttpsUrl` in `feeds.ts` and `articles.ts`. Only `http://` and `https://` are accepted; `ftp://` and other schemes are still rejected.

Routing: `articleUrlToPath` now emits `/http/<host>/<path>` for `http://` articles instead of stripping the protocol. `ArticleDetailPage` detects the `/http/` prefix and reconstructs the exact stored URL. `https://` articles keep the existing root-relative `/example.com/post` form, so all existing links, bookmarks, and share URLs remain backward compatible.

Security:
- `Referrer-Policy: strict-origin-when-cross-origin` added as a response header and meta tag. HTTPS to HTTP downgrades send no Referer, so the internal article URL is not leaked to http:// image hosts.
- CSP `img-src` is intentionally left unchanged (no `http:` added). Allowing `http:` would let any http:// image URL embedded in article content trigger GET requests from the reader's browser, and on a local-network deployment that includes LAN-internal hosts. The trade-off is that og_image thumbnails from http:// sources will not display for now. Restoring them properly requires a server-side image proxy with SSRF protection, tracked in #98.

DB protocol fallback: `getArticleByUrl` retries with the alternative protocol when an exact match fails, covering articles that were saved before http:// feeds were allowed. `getExistingArticleUrls` checks both protocols to prevent duplicate inserts for the same article referenced under different protocols in different feeds.

Frontend: `useRewriteInternalLinks` no longer coerces candidate URLs to https:// before sending them to `/api/articles/check-urls`. The backend fallback handles any mismatch that might remain from older data.

## Relationship to PR #62

This is a clean reimplementation of the approach pju-hoge developed in #62. Their branch had accumulated a stale base (it predated several merged PRs including the zap keyboard navigation work), so rather than ask for a complex rebase the changes were reapplied directly on top of main. The core design (validator relaxation, /http/ prefix, Referrer-Policy, DB fallback) follows #62 faithfully. The one deviation is the CSP change: unlike #62, img-src is not extended with http:, for the security reason described above. pju-hoge is credited as co-author.
