### PR TITLE
feat: make AI max output tokens configurable

### DIFF
--- a/docs/spec/20_api.md
+++ b/docs/spec/20_api.md
@@ -898,8 +898,10 @@ Unset items are `null`.
 | `chat.model` | Model ID depending on the provider |
 | `summary.provider` | `"anthropic"` / `"gemini"` / `"openai"` / `"claude-code"` |
 | `summary.model` | Model ID depending on the provider |
+| `summary.max_tokens` | Positive integer 1-200000 (max output tokens for summarization; default 2048). Empty string to delete |
 | `translate.provider` | `"anthropic"` / `"gemini"` / `"openai"` / `"claude-code"` / `"google-translate"` / `"deepl"` |
 | `translate.model` | Model ID depending on the provider (not needed for google-translate / deepl) |
+| `translate.max_tokens` | Positive integer 1-200000 (max output tokens for translation; default 16384). Empty string to delete |
 
 
 **GET /api/settings/api-keys/:provider** — Check API key configuration status (auth required)

--- a/docs/spec/30_ingestion.md
+++ b/docs/spec/30_ingestion.md
@@ -251,6 +251,8 @@ If the ratio of CJK characters (hiragana, katakana, kanji) in the first 1000 cha
 
 Any of Anthropic / Gemini / OpenAI can be selected from the settings screen. Streaming is supported. Provider and model can be configured independently for summarization and translation (`summary.provider`, `summary.model`, `translate.provider`, `translate.model`).
 
+The max output tokens for each task can also be overridden (`summary.max_tokens`, default 2048; `translate.max_tokens`, default 16384). This matters for local LLM backends (vLLM, Ollama) whose context window is smaller than the defaults: a request whose completion cap exceeds the backend's capacity fails outright, so lowering the cap makes summarization and translation usable on such models. Unset values fall back to the defaults.
+
 In addition to LLMs, Google Cloud Translation API v2 and DeepL API v2 are also available as translation providers. Google Translate is faster than LLMs (instant response) and offers a free tier of 500K characters per month ($20/1M characters beyond that). DeepL provides high-quality neural machine translation with particularly high accuracy for Japanese-European language pairs. API Free allows up to 500K characters per month for free; API Pro costs EUR 5.49/month + EUR 25/1M characters.
 
 **Summarization (Default: Anthropic Haiku)**

--- a/server/fetcher/ai.test.ts
+++ b/server/fetcher/ai.test.ts
@@ -130,6 +130,30 @@ describe('summarizeArticle', () => {
     expect(params.maxTokens).toBe(2048)
   })
 
+  it('uses summary.max_tokens override from settings', async () => {
+    mockGetSetting.mockImplementation((key: string) => {
+      if (key === 'summary.max_tokens') return '512'
+      return null
+    })
+    mockCreateMessage.mockResolvedValue({ text: 'ok', inputTokens: 0, outputTokens: 0 })
+    await summarizeArticle('text')
+
+    const params = mockCreateMessage.mock.calls[0][0]
+    expect(params.maxTokens).toBe(512)
+  })
+
+  it('falls back to default when summary.max_tokens is not a positive integer', async () => {
+    mockGetSetting.mockImplementation((key: string) => {
+      if (key === 'summary.max_tokens') return 'not-a-number'
+      return null
+    })
+    mockCreateMessage.mockResolvedValue({ text: 'ok', inputTokens: 0, outputTokens: 0 })
+    await summarizeArticle('text')
+
+    const params = mockCreateMessage.mock.calls[0][0]
+    expect(params.maxTokens).toBe(2048)
+  })
+
   it('uses custom model from settings', async () => {
     mockGetSetting.mockImplementation((key: string) => {
       if (key === 'summary.model') return 'claude-sonnet-4-6'
@@ -209,6 +233,18 @@ describe('translateArticle', () => {
 
     const params = mockCreateMessage.mock.calls[0][0]
     expect(params.maxTokens).toBe(16384)
+  })
+
+  it('uses translate.max_tokens override from settings', async () => {
+    mockGetSetting.mockImplementation((key: string) => {
+      if (key === 'translate.max_tokens') return '4096'
+      return null
+    })
+    mockCreateMessage.mockResolvedValue({ text: 'ok', inputTokens: 0, outputTokens: 0 })
+    await translateArticle('text')
+
+    const params = mockCreateMessage.mock.calls[0][0]
+    expect(params.maxTokens).toBe(4096)
   })
 
   it('uses translate-specific settings keys', async () => {

--- a/server/fetcher/ai.ts
+++ b/server/fetcher/ai.ts
@@ -58,8 +58,22 @@ interface AiTaskConfig {
   providerKey: string
   modelKey: string
   defaultModel: string
-  maxTokens: number
+  maxTokensKey: string
+  defaultMaxTokens: number
   buildPrompt: (text: string) => string
+}
+
+/**
+ * Resolve the max output tokens for an AI task. A positive integer stored in
+ * settings overrides the built-in default; anything else (unset, empty,
+ * malformed) falls back. Lets users with local LLMs (vLLM, Ollama) whose
+ * context window is smaller than the defaults lower the completion cap.
+ */
+function resolveMaxTokens(config: AiTaskConfig): number {
+  const raw = getSetting(config.maxTokensKey)
+  if (!raw) return config.defaultMaxTokens
+  const parsed = Number(raw)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : config.defaultMaxTokens
 }
 
 async function runAiTask(
@@ -72,14 +86,15 @@ async function runAiTask(
   const provider = getProvider(providerName)
   provider.requireKey()
   const prompt = config.buildPrompt(fullText)
+  const maxTokens = resolveMaxTokens(config)
   const result = onText
     ? await provider.streamMessage(
-        { model, maxTokens: config.maxTokens, messages: [{ role: 'user', content: prompt }] },
+        { model, maxTokens, messages: [{ role: 'user', content: prompt }] },
         onText,
       )
     : await provider.createMessage({
         model,
-        maxTokens: config.maxTokens,
+        maxTokens,
         messages: [{ role: 'user', content: prompt }],
       })
   return {
@@ -98,7 +113,8 @@ const summarizeConfig: AiTaskConfig = {
   providerKey: 'summary.provider',
   modelKey: 'summary.model',
   defaultModel: TASK_DEFAULTS.summarize.model,
-  maxTokens: SUMMARIZE_MAX_TOKENS,
+  maxTokensKey: 'summary.max_tokens',
+  defaultMaxTokens: SUMMARIZE_MAX_TOKENS,
   buildPrompt: buildSummarizePrompt,
 }
 
@@ -106,7 +122,8 @@ const translateConfig: AiTaskConfig = {
   providerKey: 'translate.provider',
   modelKey: 'translate.model',
   defaultModel: TASK_DEFAULTS.translate.model,
-  maxTokens: TRANSLATE_MAX_TOKENS,
+  maxTokensKey: 'translate.max_tokens',
+  defaultMaxTokens: TRANSLATE_MAX_TOKENS,
   buildPrompt: buildTranslatePrompt,
 }
 

--- a/server/routes/settings.test.ts
+++ b/server/routes/settings.test.ts
@@ -688,6 +688,87 @@ describe('PATCH /api/settings/preferences — retention validation', () => {
   })
 })
 
+describe('PATCH /api/settings/preferences — AI max tokens validation', () => {
+  it('accepts valid max token values', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/settings/preferences',
+      headers: json,
+      payload: { 'summary.max_tokens': '512', 'translate.max_tokens': '4096' },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()['summary.max_tokens']).toBe('512')
+    expect(res.json()['translate.max_tokens']).toBe('4096')
+  })
+
+  it('clears max tokens with an empty string', async () => {
+    await app.inject({
+      method: 'PATCH',
+      url: '/api/settings/preferences',
+      headers: json,
+      payload: { 'summary.max_tokens': '512' },
+    })
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/settings/preferences',
+      headers: json,
+      payload: { 'summary.max_tokens': '' },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()['summary.max_tokens']).toBeNull()
+  })
+
+  it('rejects non-integer max tokens', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/settings/preferences',
+      headers: json,
+      payload: { 'summary.max_tokens': '2.5' },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects zero max tokens', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/settings/preferences',
+      headers: json,
+      payload: { 'translate.max_tokens': '0' },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects negative max tokens', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/settings/preferences',
+      headers: json,
+      payload: { 'summary.max_tokens': '-100' },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects non-numeric max tokens', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/settings/preferences',
+      headers: json,
+      payload: { 'translate.max_tokens': 'lots' },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects max tokens exceeding 200000', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/settings/preferences',
+      headers: json,
+      payload: { 'summary.max_tokens': '200001' },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+})
+
 describe('vLLM endpoints', () => {
   it('GET /api/settings/vllm/status returns connection failed when unreachable', async () => {
     const mockFetch = vi.fn().mockRejectedValue(new Error('fetch failed'))

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -46,8 +46,10 @@ const PREF_KEYS = [
   'chat.model',
   'summary.provider',
   'summary.model',
+  'summary.max_tokens',
   'translate.provider',
   'translate.model',
+  'translate.max_tokens',
   'translate.target_lang',
   'ollama.base_url',
   'ollama.custom_headers',
@@ -80,8 +82,10 @@ const PREF_ALLOWED: Record<PrefKey, string[] | null> = {
   'chat.model': getAllModelValues(),
   'summary.provider': ['anthropic', 'gemini', 'openai', 'claude-code', 'ollama', 'vllm'],
   'summary.model': getAllModelValues(),
+  'summary.max_tokens': null,
   'translate.provider': ['anthropic', 'gemini', 'openai', 'claude-code', 'ollama', 'vllm', 'google-translate', 'deepl'],
   'translate.model': getAllModelValues(),
+  'translate.max_tokens': null,
   'translate.target_lang': ['ja', 'en', 'zh'],
   'ollama.base_url': null,
   'ollama.custom_headers': null,
@@ -239,6 +243,14 @@ export async function settingsRoutes(api: FastifyInstance): Promise<void> {
         const parsed = z.coerce.number().int().min(1).max(9999).safeParse(value)
         if (!parsed.success) {
           reply.status(400).send({ error: `${key} must be a positive integer (1-9999)` })
+          return
+        }
+      }
+      // Validate AI max tokens: must be a positive integer
+      if (key === 'summary.max_tokens' || key === 'translate.max_tokens') {
+        const parsed = z.coerce.number().int().min(1).max(200000).safeParse(value)
+        if (!parsed.success) {
+          reply.status(400).send({ error: `${key} must be a positive integer (1-200000)` })
           return
         }
       }

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -45,8 +45,10 @@ interface Prefs {
   'chat.model': string | null
   'summary.provider': string | null
   'summary.model': string | null
+  'summary.max_tokens': string | null
   'translate.provider': string | null
   'translate.model': string | null
+  'translate.max_tokens': string | null
   'translate.target_lang': string | null
   'custom_themes': string | null
 }
@@ -84,6 +86,8 @@ export function useSettings() {
   const [translateProvider, setTranslateProviderState] = useState<string | null>(null)
   const [translateModel, setTranslateModelState] = useState<string | null>(null)
   const [translateTargetLang, setTranslateTargetLangState] = useState<string | null>(null)
+  const [summaryMaxTokens, setSummaryMaxTokensState] = useState<string | null>(null)
+  const [translateMaxTokens, setTranslateMaxTokensState] = useState<string | null>(null)
 
   // --- DB sync ---
   const { data: prefs, mutate: mutatePrefs } = useSWR<Prefs>(
@@ -175,6 +179,8 @@ export function useSettings() {
       { key: 'translate.provider', setter: setTranslateProviderState },
       { key: 'translate.model', setter: setTranslateModelState },
       { key: 'translate.target_lang', setter: setTranslateTargetLangState },
+      { key: 'summary.max_tokens', setter: setSummaryMaxTokensState },
+      { key: 'translate.max_tokens', setter: setTranslateMaxTokensState },
     ]
 
     for (const { key, setter, backfillRef, validate } of hydrationMap) {
@@ -316,6 +322,8 @@ export function useSettings() {
     syncedSetTranslateProvider,
     syncedSetTranslateModel,
     syncedSetTranslateTargetLang,
+    syncedSetSummaryMaxTokens,
+    syncedSetTranslateMaxTokens,
   } = useMemo(() => {
     const make = <T extends string>(key: keyof Prefs, setter: (v: T) => void) =>
       (value: T) => {
@@ -351,6 +359,8 @@ export function useSettings() {
       syncedSetTranslateProvider: make<string>('translate.provider', setTranslateProviderState),
       syncedSetTranslateModel: make<string>('translate.model', setTranslateModelState),
       syncedSetTranslateTargetLang: make<string>('translate.target_lang', setTranslateTargetLangState),
+      syncedSetSummaryMaxTokens: make<string>('summary.max_tokens', setSummaryMaxTokensState),
+      syncedSetTranslateMaxTokens: make<string>('translate.max_tokens', setTranslateMaxTokensState),
     }
     // scheduleSave and dirtyKeysRef are stable refs; remaining setters are useState/useCallback-stable
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -439,6 +449,10 @@ export function useSettings() {
     setTranslateModel: syncedSetTranslateModel,
     translateTargetLang,
     setTranslateTargetLang: syncedSetTranslateTargetLang,
+    summaryMaxTokens,
+    setSummaryMaxTokens: syncedSetSummaryMaxTokens,
+    translateMaxTokens,
+    setTranslateMaxTokens: syncedSetTranslateMaxTokens,
     keyboardNavigation,
     setKeyboardNavigation: syncedSetKeyboardNavigation,
     keybindings,

--- a/src/lib/demo/mock-api.ts
+++ b/src/lib/demo/mock-api.ts
@@ -139,8 +139,10 @@ export async function demoFetcher(url: string): Promise<unknown> {
       'chat.model': 'claude-haiku-4-5-20251001',
       'summary.provider': 'anthropic',
       'summary.model': 'claude-haiku-4-5-20251001',
+      'summary.max_tokens': null,
       'translate.provider': 'deepl',
       'translate.model': '',
+      'translate.max_tokens': null,
       'translate.target_lang': null,
     }
   }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -510,6 +510,8 @@ const dict = {
   'integration.task.chat': { ja: 'チャット', en: 'Chat', zh: '聊天'},
   'integration.task.summary': { ja: '要約', en: 'Summary', zh: '摘要'},
   'integration.task.translate': { ja: '翻訳', en: 'Translation', zh: '翻译'},
+  'integration.maxTokens': { ja: '最大出力トークン数', en: 'Max output tokens', zh: '最大输出 token 数'},
+  'integration.maxTokensDesc': { ja: '空欄でデフォルト値を使用。コンテキスト長が短いローカルLLMでは小さくしてください', en: 'Empty uses the default. Lower this for local LLMs with small context windows', zh: '留空使用默认值。上下文窗口较小的本地 LLM 请调低此值'},
   'integration.modeLLM': { ja: 'LLM', en: 'LLM', zh: 'LLM'},
   'integration.modeTranslateService': { ja: '翻訳サービス', en: 'Translation Service', zh: '翻译服务'},
   'integration.googleTranslateNote': {

--- a/src/pages/settings/sections/task-model-section.tsx
+++ b/src/pages/settings/sections/task-model-section.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../data/aiModels'
 import type { ModelGroup } from '../../../data/aiModels'
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectGroup, SelectLabel, SelectItem } from '@/components/ui/select'
+import { Input } from '@/components/ui/input'
 import type { Settings } from '../../../hooks/use-settings'
 import type { TranslateFn } from '../../../lib/i18n'
 
@@ -27,6 +28,9 @@ interface TaskConfig {
   setModel: (v: string) => void
   defaultModel: string
   hasTranslateServices?: boolean
+  maxTokensValue?: string
+  setMaxTokens?: (v: string) => void
+  defaultMaxTokens?: number
 }
 
 const SWR_KEY_OPTS = { revalidateOnFocus: false } as const
@@ -91,6 +95,9 @@ export function TaskModelSection({ settings, t }: { settings: Settings; t: TFunc
       modelValue: settings.summaryModel || '',
       setModel: settings.setSummaryModel,
       defaultModel: 'claude-haiku-4-5-20251001',
+      maxTokensValue: settings.summaryMaxTokens || '',
+      setMaxTokens: settings.setSummaryMaxTokens,
+      defaultMaxTokens: 2048,
     },
     {
       labelKey: 'integration.task.translate',
@@ -104,13 +111,16 @@ export function TaskModelSection({ settings, t }: { settings: Settings; t: TFunc
       setModel: settings.setTranslateModel,
       defaultModel: 'claude-sonnet-4-6',
       hasTranslateServices: true,
+      maxTokensValue: settings.translateMaxTokens || '',
+      setMaxTokens: settings.setTranslateMaxTokens,
+      defaultMaxTokens: 16384,
     },
   ]
 
   // Show brief "Saved" feedback on any task provider/model change
   const [showSaved, setShowSaved] = useState(false)
-  const prevValues = useRef(tasks.map(t => `${t.providerValue}:${t.modelValue}`).join('|'))
-  const currentValues = tasks.map(t => `${t.providerValue}:${t.modelValue}`).join('|')
+  const prevValues = useRef(tasks.map(t => `${t.providerValue}:${t.modelValue}:${t.maxTokensValue ?? ''}`).join('|'))
+  const currentValues = tasks.map(t => `${t.providerValue}:${t.modelValue}:${t.maxTokensValue ?? ''}`).join('|')
   useEffect(() => {
     if (prevValues.current !== currentValues) {
       prevValues.current = currentValues
@@ -170,6 +180,7 @@ function TaskModelRow({ task, t, configuredKeys, hasAnyTranslateKey }: { task: T
         <span className="block text-xs font-medium text-text select-none">{t(task.labelKey)}</span>
         <ProviderButtons providers={LLM_TASK_PROVIDERS} selected={task.providerValue} onSelect={task.setProvider} t={t} configuredKeys={configuredKeys} />
         <ModelSelect provider={task.providerValue} modelValue={task.modelValue} setModel={task.setModel} t={t} />
+        {task.setMaxTokens && <MaxTokensInput task={task} t={t} />}
       </div>
     )
   }
@@ -214,8 +225,39 @@ function TaskModelRow({ task, t, configuredKeys, hasAnyTranslateKey }: { task: T
         <>
           <ProviderButtons providers={LLM_TASK_PROVIDERS} selected={task.providerValue} onSelect={task.setProvider} t={t} configuredKeys={configuredKeys} />
           <ModelSelect provider={task.providerValue} modelValue={task.modelValue} setModel={task.setModel} t={t} />
+          {task.setMaxTokens && <MaxTokensInput task={task} t={t} />}
         </>
       )}
+    </div>
+  )
+}
+
+/* ── Max Tokens Input ── */
+
+const MAX_TOKENS_LIMIT = 200000
+
+function MaxTokensInput({ task, t }: { task: TaskConfig; t: TFunc }) {
+  const onChange = (raw: string) => {
+    // Digits only; strip leading zeros so '0' clears back to the default.
+    // Clamp to the server-side limit so the debounced PATCH never gets a 400.
+    const digits = raw.replace(/\D/g, '').replace(/^0+/, '')
+    task.setMaxTokens!(digits ? String(Math.min(Number(digits), MAX_TOKENS_LIMIT)) : '')
+  }
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="min-w-0">
+        <span className="block text-[11px] text-text select-none">{t('integration.maxTokens')}</span>
+        <span className="block text-[11px] text-muted/70 select-none">{t('integration.maxTokensDesc')}</span>
+      </div>
+      <Input
+        type="text"
+        inputMode="numeric"
+        value={task.maxTokensValue ?? ''}
+        onChange={e => onChange(e.target.value)}
+        placeholder={String(task.defaultMaxTokens)}
+        className="w-24 text-right shrink-0"
+        aria-label={t('integration.maxTokens')}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Make the max output tokens for summarization and translation configurable via settings. Closes #97.

## Background

The completion caps for AI tasks were hardcoded in server/fetcher/ai.ts (SUMMARIZE_MAX_TOKENS = 2048, TRANSLATE_MAX_TOKENS = 16384). Local LLM backends (vLLM, Ollama) with context windows smaller than these caps reject every request, which made translation entirely unusable on such setups with no workaround in the UI. See #97 for the design discussion; an explicit universal setting was chosen over auto-probing the backend's context window.

## Changes

- Add summary.max_tokens and translate.max_tokens as DB-backed preferences with positive-integer validation (1-200000); empty string clears back to the default
- Resolve the effective cap in runAiTask: a positive integer from settings overrides, anything else falls back to the built-in defaults, so existing installs see no behavior change
- Add number inputs next to the Summary and Translation model selection in Settings → Integration (placeholder shows the default; input is digits-only and clamped client-side so the debounced PATCH never 400s)
- Wire both keys through use-settings.ts hydration/sync and the demo-mode preferences mock
- i18n keys in ja/en/zh
- Tests: preference validation (7 cases) and maxTokens resolution in the AI task runner (3 cases)
- Docs: preferences table in 20_api.md, AI section in 30_ingestion.md
