### PR TITLE
feat: drag-and-drop category reordering

### DIFF
--- a/src/components/feed/feed-list.tsx
+++ b/src/components/feed/feed-list.tsx
@@ -11,6 +11,7 @@ import { useFetchProgressContext } from '../../contexts/fetch-progress-context'
 import { toast } from 'sonner'
 import { useFeedActions } from '../../hooks/use-feed-actions'
 import { useFeedDragDrop } from '../../hooks/use-feed-drag-drop'
+import { useCategoryDragDrop } from '../../hooks/use-category-drag-drop'
 import { useFeedSelection } from '../../hooks/use-feed-selection'
 import { useFeedBulkActions } from '../../hooks/use-feed-bulk-actions'
 import { useClipFeedId } from '../../hooks/use-clip-feed-id'
@@ -191,6 +192,11 @@ export function FeedList({ isOpen, onClose, onBackdropClose, onCollapse, onMarkA
     dragOverTarget, isDragging,
     handleDragStart, handleDragOver, handleDragLeave, handleDrop, handleDragEnd,
   } = useFeedDragDrop({ feeds, mutateFeeds, onDropComplete: clearSelection })
+
+  const {
+    isCategoryDrag,
+    handleCategoryDragStart, handleCategoryDrop, handleCategoryDragEnd,
+  } = useCategoryDragDrop({ categories, mutateCategories })
 
   const {
     bulkDeleteConfirm, setBulkDeleteConfirm,
@@ -399,9 +405,12 @@ export function FeedList({ isOpen, onClose, onBackdropClose, onCollapse, onMarkA
     return (
       <div
         key={category.id}
+        draggable={!isRenaming}
+        onDragStart={e => handleCategoryDragStart(e, category)}
+        onDragEnd={handleCategoryDragEnd}
         onDragOver={e => handleDragOver(e, category.id)}
         onDragLeave={handleDragLeave}
-        onDrop={e => handleDrop(e, category.id)}
+        onDrop={e => isCategoryDrag(e) ? void handleCategoryDrop(e, category) : handleDrop(e, category.id)}
         className={`rounded-lg transition-colors ${dragOverTarget === category.id ? 'bg-hover-sidebar' : ''}`}
       >
         <CategoryContextMenu

--- a/src/hooks/use-category-drag-drop.test.ts
+++ b/src/hooks/use-category-drag-drop.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useCategoryDragDrop } from './use-category-drag-drop'
+import type { Category } from '../../shared/types'
+
+vi.mock('../lib/fetcher', () => ({
+  apiPatch: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { apiPatch } from '../lib/fetcher'
+
+function makeCategory(overrides: Partial<Category> = {}): Category {
+  return {
+    id: 1,
+    name: 'Category',
+    sort_order: 0,
+    collapsed: 0,
+    created_at: '2024-01-01',
+    ...overrides,
+  }
+}
+
+function makeDragEvent(): React.DragEvent {
+  const data = new Map<string, string>()
+  return {
+    preventDefault: vi.fn(),
+    dataTransfer: {
+      setData: (k: string, v: string) => data.set(k, v),
+      getData: (k: string) => data.get(k) ?? '',
+      get types() { return Array.from(data.keys()) },
+      effectAllowed: 'uninitialized',
+      dropEffect: 'none',
+    },
+  } as unknown as React.DragEvent
+}
+
+describe('useCategoryDragDrop', () => {
+  const categories = [
+    makeCategory({ id: 1, name: 'A', sort_order: 0 }),
+    makeCategory({ id: 2, name: 'B', sort_order: 1 }),
+    makeCategory({ id: 3, name: 'C', sort_order: 2 }),
+  ]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mutateCategories: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mutateCategories = vi.fn()
+  })
+
+  it('initializes with no dragging category', () => {
+    const { result } = renderHook(() => useCategoryDragDrop({ categories, mutateCategories }))
+    expect(result.current.draggingCategoryId).toBeNull()
+  })
+
+  it('handleCategoryDragStart transfers the category id', () => {
+    const { result } = renderHook(() => useCategoryDragDrop({ categories, mutateCategories }))
+    const event = makeDragEvent()
+
+    act(() => result.current.handleCategoryDragStart(event, categories[0]))
+
+    expect(result.current.draggingCategoryId).toBe(1)
+    expect(event.dataTransfer.effectAllowed).toBe('move')
+    expect(event.dataTransfer.getData('application/x-category-id')).toBe('1')
+  })
+
+  it('isCategoryDrag distinguishes category drags from other drags', () => {
+    const { result } = renderHook(() => useCategoryDragDrop({ categories, mutateCategories }))
+    const categoryEvent = makeDragEvent()
+    act(() => result.current.handleCategoryDragStart(categoryEvent, categories[0]))
+    expect(result.current.isCategoryDrag(categoryEvent)).toBe(true)
+
+    const otherEvent = makeDragEvent()
+    otherEvent.dataTransfer.setData('application/x-feed-ids', '[1]')
+    expect(result.current.isCategoryDrag(otherEvent)).toBe(false)
+  })
+
+  it('handleCategoryDrop moves the dragged category before the target and persists new order', async () => {
+    const { result } = renderHook(() => useCategoryDragDrop({ categories, mutateCategories }))
+    const event = makeDragEvent()
+    event.dataTransfer.setData('application/x-category-id', '3') // drag C onto A
+
+    await act(async () => {
+      await result.current.handleCategoryDrop(event, categories[0])
+    })
+
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(result.current.draggingCategoryId).toBeNull()
+    expect(mutateCategories).toHaveBeenCalledWith(expect.any(Function), { revalidate: false })
+
+    const updater = mutateCategories.mock.calls[0][0]
+    const updated = updater({ categories })
+    // New order: C, A, B → sort_order 0, 1, 2
+    expect(updated.categories.find((c: Category) => c.id === 3).sort_order).toBe(0)
+    expect(updated.categories.find((c: Category) => c.id === 1).sort_order).toBe(1)
+    expect(updated.categories.find((c: Category) => c.id === 2).sort_order).toBe(2)
+    // The array itself must be reordered too — render order comes from array order, not from re-sorting sort_order client-side
+    expect(updated.categories.map((c: Category) => c.id)).toEqual([3, 1, 2])
+
+    expect(apiPatch).toHaveBeenCalledWith('/api/categories/3', { sort_order: 0 })
+    expect(apiPatch).toHaveBeenCalledWith('/api/categories/1', { sort_order: 1 })
+    expect(apiPatch).toHaveBeenCalledWith('/api/categories/2', { sort_order: 2 })
+  })
+
+  it('handleCategoryDrop is a no-op when dropped on itself', async () => {
+    const { result } = renderHook(() => useCategoryDragDrop({ categories, mutateCategories }))
+    const event = makeDragEvent()
+    event.dataTransfer.setData('application/x-category-id', '1')
+
+    await act(async () => {
+      await result.current.handleCategoryDrop(event, categories[0])
+    })
+
+    expect(mutateCategories).not.toHaveBeenCalled()
+    expect(apiPatch).not.toHaveBeenCalled()
+  })
+
+  it('handleCategoryDrop skips if dragged id is invalid', async () => {
+    const { result } = renderHook(() => useCategoryDragDrop({ categories, mutateCategories }))
+    const event = makeDragEvent()
+
+    await act(async () => {
+      await result.current.handleCategoryDrop(event, categories[0])
+    })
+
+    expect(mutateCategories).not.toHaveBeenCalled()
+  })
+
+  it('handleCategoryDrop reverts on API failure', async () => {
+    vi.mocked(apiPatch).mockRejectedValueOnce(new Error('Network error'))
+    const { result } = renderHook(() => useCategoryDragDrop({ categories, mutateCategories }))
+    const event = makeDragEvent()
+    event.dataTransfer.setData('application/x-category-id', '3')
+
+    await act(async () => {
+      await result.current.handleCategoryDrop(event, categories[0])
+    })
+
+    // First call: optimistic update, second call: revalidate on error
+    expect(mutateCategories).toHaveBeenCalledTimes(2)
+    expect(mutateCategories).toHaveBeenLastCalledWith()
+  })
+
+  it('handleCategoryDragEnd resets dragging state', () => {
+    const { result } = renderHook(() => useCategoryDragDrop({ categories, mutateCategories }))
+    act(() => result.current.handleCategoryDragStart(makeDragEvent(), categories[0]))
+    act(() => result.current.handleCategoryDragEnd())
+    expect(result.current.draggingCategoryId).toBeNull()
+  })
+})

--- a/src/hooks/use-category-drag-drop.ts
+++ b/src/hooks/use-category-drag-drop.ts
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import { apiPatch } from '../lib/fetcher'
+import type { Category } from '../../shared/types'
+import type { KeyedMutator } from 'swr'
+
+const CATEGORY_DND_TYPE = 'application/x-category-id'
+
+interface UseCategoryDragDropOpts {
+  categories: Category[]
+  mutateCategories: KeyedMutator<{ categories: Category[] }>
+}
+
+export function useCategoryDragDrop({ categories, mutateCategories }: UseCategoryDragDropOpts) {
+  const [draggingCategoryId, setDraggingCategoryId] = useState<number | null>(null)
+
+  function handleCategoryDragStart(e: React.DragEvent, category: Category) {
+    e.dataTransfer.setData(CATEGORY_DND_TYPE, String(category.id))
+    e.dataTransfer.effectAllowed = 'move'
+    setDraggingCategoryId(category.id)
+  }
+
+  function isCategoryDrag(e: React.DragEvent): boolean {
+    return e.dataTransfer.types.includes(CATEGORY_DND_TYPE)
+  }
+
+  /** Moves the dragged category to `targetCategory`'s position and persists the new sort_order for every category whose position changed. */
+  async function handleCategoryDrop(e: React.DragEvent, targetCategory: Category) {
+    e.preventDefault()
+    const draggedId = Number(e.dataTransfer.getData(CATEGORY_DND_TYPE))
+    setDraggingCategoryId(null)
+    if (!draggedId || draggedId === targetCategory.id) return
+
+    const ordered = [...categories].sort((a, b) => a.sort_order - b.sort_order)
+    const fromIndex = ordered.findIndex(c => c.id === draggedId)
+    const toIndex = ordered.findIndex(c => c.id === targetCategory.id)
+    if (fromIndex === -1 || toIndex === -1) return
+
+    const reordered = [...ordered]
+    const [dragged] = reordered.splice(fromIndex, 1)
+    reordered.splice(toIndex, 0, dragged)
+    const withSortOrder = reordered.map((c, i) => ({ ...c, sort_order: i }))
+
+    const sortOrderById = new Map(withSortOrder.map(c => [c.id, c.sort_order]))
+
+    void mutateCategories(
+      prev => prev ? { categories: withSortOrder } : prev,
+      { revalidate: false },
+    )
+
+    try {
+      await Promise.all(
+        ordered
+          .filter(c => sortOrderById.get(c.id) !== c.sort_order)
+          .map(c => apiPatch(`/api/categories/${c.id}`, { sort_order: sortOrderById.get(c.id) })),
+      )
+    } catch {
+      void mutateCategories()
+    }
+  }
+
+  function handleCategoryDragEnd() {
+    setDraggingCategoryId(null)
+  }
+
+  return {
+    draggingCategoryId,
+    isCategoryDrag,
+    handleCategoryDragStart,
+    handleCategoryDrop,
+    handleCategoryDragEnd,
+  }
+}


### PR DESCRIPTION
## What this does

Right now, categories (feed folders) in the sidebar always show up in the order they were created — there's no way to move "Tech" above "News", for example. This PR adds that: drag a category and drop it on another one, and it moves there. The new order sticks — reload the page, restart the server, doesn't matter, it's saved.

The database and API already had everything needed for this (a `sort_order` column, a way to update it) — it just wasn't wired up to anything in the UI. So this is mostly a frontend change.

## How it works

New hook `src/hooks/use-category-drag-drop.ts`, using the same plain browser drag-and-drop the app already uses for dragging feeds between categories (`use-feed-drag-drop.ts`) — no new library. Drop a category on another one, it takes that spot, and every category that shifted gets its new position saved in the background (with the UI updating instantly, and rolling back if the save fails).

One thing that tripped me up while testing by hand: the sidebar trusts the order the server sends and doesn't re-sort locally. My first version updated each category's saved position correctly but didn't reorder the on-screen list — so the database was right but the sidebar looked unchanged until you refreshed. Fixed by making sure the list itself gets reordered, not just the numbers behind it.

## Testing

- 8 new unit tests for the hook
- `tsc --noEmit` and `eslint` clean
- Full suite: 127 files / 2098 tests passing
- Tried it by hand in the browser: drag, drop, order changes immediately, survives a full reload

## Compatibility

Nothing changes for anyone who doesn't use this — categories keep showing up in whatever order they already were. No database migration, no API changes.